### PR TITLE
fix(test): shim localStorage for jsdom 25 / Node 25

### DIFF
--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -25,4 +25,36 @@ if (typeof window !== "undefined") {
       dispatchEvent: () => false,
     })) as unknown as typeof window.matchMedia;
   }
+
+  // Web Storage stub. jsdom (25) under Node (>=25) exposes window.localStorage
+  // but its methods are not functions, so reads at module init — e.g. the theme
+  // and runtime stores — throw "getItem is not a function". Shim an in-memory
+  // store so importing those modules doesn't break the suites that touch them.
+  if (typeof window.localStorage?.getItem !== "function") {
+    const store = new Map<string, string>();
+    const shim: Storage = {
+      get length() {
+        return store.size;
+      },
+      clear: () => store.clear(),
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      setItem: (k: string, v: string) => {
+        store.set(k, String(v));
+      },
+    };
+    Object.defineProperty(window, "localStorage", {
+      value: shim,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      value: shim,
+      configurable: true,
+      writable: true,
+    });
+  }
 }


### PR DESCRIPTION
## Problem

14 of 57 frontend test suites fail under **Node ≥ 25** with `jsdom@25`:

```
TypeError: window.localStorage.getItem is not a function
 ❯ initialTheme src/lib/store.ts:21:37
 ❯ initialUrl  src/lib/runtime.ts:44:30
```

Affected suites touch the Zustand stores (`store.ts`, `runtime.ts`), which call `localStorage.getItem()` at module init — e.g. `FilesPage`, `RunsPage`, `SessionPage`, `Composer`, `CommandPalette`, `ArtifactInspector`, `NotebookEditor`, `store.test`, `runtime.test`, etc.

## Root cause

Not a bug in the app code. `jsdom@25` exposes `window.localStorage`, but its methods are not functions (Web Storage is left unimplemented), so any read throws. The test setup (`src/test/setup.ts`) already shims `matchMedia` and `ResizeObserver` for similar gaps but was missing `localStorage`.

## Fix

Add an in-memory Web Storage shim to `src/test/setup.ts`, guarded so it only installs when the real methods are absent (won't override a real implementation):

```ts
if (typeof window.localStorage?.getItem !== "function") {
  const store = new Map<string, string>();
  const shim: Storage = { /* getItem/setItem/removeItem/clear/key/length */ };
  Object.defineProperty(window, "localStorage",  { value: shim, configurable: true, writable: true });
  Object.defineProperty(window, "sessionStorage",{ value: shim, configurable: true, writable: true });
}
```

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ **370/370 tests · 57/57 suites** (was 227 passed / 14 suites failed)
- `cargo test` ✅ 63/63 (unaffected)

Reproduces for anyone on Node ≥ 24 + jsdom 25. Single file changed (`+32` lines), no production code touched.