### PR TITLE
RFC + impl: formalize an AgentRuntime interface boundary

### DIFF
--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -3,6 +3,7 @@ import {
   OpenCodeClient,
   DEFAULT_OPENCODE_URL,
   type AgentInfo,
+  type AgentRuntime,
   type CommandInfo,
   type HistoryMessage,
   type OpenCodeEvent,
@@ -185,7 +186,12 @@ interface RuntimeState {
   installSkill: (text: string) => Promise<string | null>;
 }
 
-let client: OpenCodeClient | null = null;
+// The internal store depends only on the runtime-agnostic AgentRuntime contract
+// (see docs/rfc/agent-runtime.md). The concrete reference (opencodeClient) is
+// kept separately so getClient() can hand Settings/setup the full OpenCode
+// provider/MCP surface that lives outside the AgentRuntime contract.
+let client: AgentRuntime | null = null;
+let opencodeClient: OpenCodeClient | null = null;
 let openSessionSeq = 0;
 /** React StrictMode mounts effects twice in development. Share the same boot
  *  promise so duplicate AppShell effects cannot start dueling connect loops. */
@@ -209,6 +215,7 @@ function teardownClient() {
   clearStatusBlip();
   client?.close();
   client = null;
+  opencodeClient = null;
 }
 const emptyThread = (): Thread => ({ blocks: [], index: {}, loaded: false });
 /** Threads key for the draft conversation — its blocks move to the real
@@ -447,7 +454,7 @@ async function performTurn(
 
 /** The live OpenCode client (Settings talks to the runtime's config API directly). */
 export function getClient(): OpenCodeClient | null {
-  return client;
+  return opencodeClient;
 }
 
 export const useRuntimeStore = create<RuntimeState>((set, get) => ({
@@ -656,6 +663,7 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
       directory: directory ?? undefined,
       password: password ?? undefined,
     });
+    opencodeClient = c;
     client = c;
     clientStatusUnsub = c.onStatus((status) => {
       void logDebug(`status → ${status}`);

--- a/docs/rfc/agent-runtime.md
+++ b/docs/rfc/agent-runtime.md
@@ -1,7 +1,7 @@
 # RFC: An `AgentRuntime` boundary
 
-Status: **Proposal — seeking discussion. No code change requested in this PR.**
-Target: post-v0.4.0 (see "Timing").
+Status: **Phase 1 implemented in this PR; Phases 2–3 open for discussion.**
+Target: land before v0.4.0 ACP work (see "Timing").
 
 ## TL;DR
 
@@ -65,14 +65,15 @@ Three reasons, in order of weight:
 - **No event-name neutralization now.** Renaming `message.part.updated` → a neutral
   name is deferred (it is the noisiest part; see "Phases").
 
-## Proposed interface (illustrative, not a patch)
+## Proposed interface (implemented in this PR)
 
-Derived from the **15 runtime methods + 2 listener hooks `lib/runtime.ts` actually
+Derived from the **runtime methods + listener hooks `lib/runtime.ts` actually
 uses today** (verified by grep). Nothing invented; this is the current surface,
-named and contracted.
+named and contracted. The interface lives at `packages/sdk/src/runtime.ts`, and
+`OpenCodeClient` now `implements AgentRuntime`.
 
 ```ts
-// packages/sdk/src/runtime.ts  (proposed, not yet created)
+// packages/sdk/src/runtime.ts
 
 /** The boundary AGENTS.md already mandates. OpenCodeClient is the sole impl. */
 export interface AgentRuntime {
@@ -100,9 +101,16 @@ export interface AgentRuntime {
   getDefaultModel(): Promise<string | null>;
   setDefaultModel(model: string): Promise<void>;
 
+  // agent-driven execution (a full turn, not a single prompt)
+  runShell(sessionId: string, command: string, agent?: string): Promise<void>;
+  runCommand(sessionId: string, command: string, args?: string): Promise<void>;
+
   // interactive requests (agent asks; user must answer)
+  listQuestions(sessionId?: string): Promise<QuestionAskedEvent[]>;
+  listPermissions(sessionId?: string): Promise<PermissionAskedEvent[]>;
   answerQuestion(requestId: string, answers: string[][]): Promise<void>;
   rejectQuestion(requestId: string): Promise<void>;
+  replyPermission(requestId: string, reply: PermissionReply): Promise<void>;
 }
 ```
 
@@ -138,13 +146,13 @@ starts is the main timing argument.
 
 | Phase | Change | Risk | Reversible |
 | --- | --- | --- | --- |
-| **0** (this RFC) | Discussion only. Document the seam, agree on the method set. | None | N/A |
-| **1** | Add `interface AgentRuntime`; `OpenCodeClient implements AgentRuntime`. `lib/runtime.ts` types against the interface, still constructed as `new OpenCodeClient(...)`. No behavior change. | Trivial | Yes |
+| **0** | Discussion only. Document the seam, agree on the method set. | None | N/A |
+| **1** (this PR) ✅ | Add `interface AgentRuntime`; `OpenCodeClient implements AgentRuntime`. `lib/runtime.ts` types its internal `client` against the interface, still constructed as `new OpenCodeClient(...)`. No behavior change. typecheck + lint green; `opencode-client.node.test.ts` (16 tests) green. | Trivial | Yes |
 | **2** | Decide event-name neutralization: alias OpenCode wire names behind `RuntimeEvent`. | Low | Yes |
 | **3** (future, out of scope) | A second runtime, ACP adapter, or a "custom endpoint" provider — only if a concrete need appears. | — | — |
 
-**Phase 1 is the entire ask behind this RFC.** Phases 2–3 are listed so reviewers
-see the trajectory and can object early.
+**Phase 1 is implemented in this PR.** Phases 2–3 are listed so reviewers see the
+trajectory and can object early.
 
 ## Open questions (what I want from discussion)
 

--- a/docs/rfc/agent-runtime.md
+++ b/docs/rfc/agent-runtime.md
@@ -1,0 +1,189 @@
+# RFC: An `AgentRuntime` boundary
+
+Status: **Proposal — seeking discussion. No code change requested in this PR.**
+Target: post-v0.4.0 (see "Timing").
+
+## TL;DR
+
+Open Science Desktop already treats `packages/sdk` as *the* boundary between the
+UI and the agent runtime (an architecture rule in `AGENTS.md`). In practice the
+boundary is a **concrete class, `OpenCodeClient`**, not an interface, and the only
+runtime is a bundled OpenCode sidecar. This RFC proposes formalizing that boundary
+as a small, runtime-agnostic **`AgentRuntime` interface** that `OpenCodeClient`
+implements — **no behavioral change, no second runtime, no user-facing switch** —
+so the seam the project already depends on is explicit and ready for future work.
+
+## Motivation
+
+### What the docs promise
+
+`AGENTS.md` and `docs/PRD.md` (§10.3) both name "agent runtime decoupled" and
+"pluggable" as an architectural goal. The `TECHNICAL_DESIGN.md` one-liner calls
+the project a "replaceable agent runtime."
+
+### What the code does today
+
+The seam exists, but informally. The whole app reaches the runtime through one
+class, and one place builds it:
+
+| Layer | Fact | Reference |
+| --- | --- | --- |
+| SDK | A single concrete class, no `interface` | `packages/sdk/src/OpenCodeClient.ts:54` |
+| Frontend | Exactly **one** instantiation site | `apps/desktop/src/lib/runtime.ts:654` |
+| Store | Imports the concrete class, not an abstraction | `apps/desktop/src/lib/runtime.ts:3` |
+| Events | Type names are OpenCode's wire names (`message.part.updated`) | `packages/sdk/src/types.ts` |
+| Desktop shell | Bundles and supervises the OpenCode binary | `apps/desktop/src-tauri/src/runtime.rs` |
+
+The "decoupling" is real *de facto* — every call is centralized — but it is not
+*expressed* in the types. A maintainer cannot tell from a signature "this part is
+runtime-specific" vs. "this part is the app's contract."
+
+### Why formalize it now (without building a second runtime)
+
+Three reasons, in order of weight:
+
+1. **It is cheap and nearly free.** The interface already exists implicitly; this
+   only makes it `export interface`. No behavior changes, no migration, no risk to
+   the shipping app. Pure YAGNI-safe: we extract *what is already there*.
+2. **It sharpens future discussions.** Upstream's v0.4.0 plan includes
+   **Agent Client Protocol (ACP)** support (#14) and **LAN / messaging surfaces**
+   (#3, #20). Both touch "what does it mean to drive the runtime?" Having a named
+   boundary lets those features be debated against a stable contract instead of
+   against `OpenCodeClient`'s private method list.
+3. **It records the seam for contributors.** A new contributor reading
+   `lib/runtime.ts` today cannot see which methods are essential vs. incidental.
+   An interface with a short contract per method answers that in one place.
+
+### Non-goals
+
+- **No second runtime.** This RFC does *not* propose building an alternative to
+  OpenCode. OpenCode remains the only implementation.
+- **No user-facing "choose your runtime" setting.** Product surface stays exactly
+  as today.
+- **No ACP implementation.** ACP is referenced as *alignment context*, not as work
+  this RFC does. See "Relationship to ACP".
+- **No event-name neutralization now.** Renaming `message.part.updated` → a neutral
+  name is deferred (it is the noisiest part; see "Phases").
+
+## Proposed interface (illustrative, not a patch)
+
+Derived from the **15 runtime methods + 2 listener hooks `lib/runtime.ts` actually
+uses today** (verified by grep). Nothing invented; this is the current surface,
+named and contracted.
+
+```ts
+// packages/sdk/src/runtime.ts  (proposed, not yet created)
+
+/** The boundary AGENTS.md already mandates. OpenCodeClient is the sole impl. */
+export interface AgentRuntime {
+  // lifecycle
+  connect(): Promise<void>;
+  close(): void;
+  getStatus(): RuntimeStatus;
+  onStatus(listener: (s: RuntimeStatus) => void): () => void;
+  onEvent(listener: (e: RuntimeEvent) => void): () => void;
+
+  // sessions (a conversation)
+  createSession(): Promise<string>;
+  listSessions(): Promise<SessionMeta[]>;
+  deleteSession(id: string): Promise<void>;
+  getMessages(id: string): Promise<HistoryMessage[]>;
+  sendPrompt(id: string, text: string): Promise<void>;
+  abortSession(id: string): Promise<void>;
+
+  // discovery (what this runtime can do)
+  listSkills(): Promise<SkillInfo[]>;
+  listAgents(): Promise<AgentInfo[]>;
+  listCommands(): Promise<CommandInfo[]>;
+
+  // model selection
+  getDefaultModel(): Promise<string | null>;
+  setDefaultModel(model: string): Promise<void>;
+
+  // interactive requests (agent asks; user must answer)
+  answerQuestion(requestId: string, answers: string[][]): Promise<void>;
+  rejectQuestion(requestId: string): Promise<void>;
+}
+```
+
+Notes on the contract:
+
+- **Provider/MCP/OAuth methods are intentionally excluded.** They are
+  *configuration* of OpenCode-the-implementation, not of "an agent runtime." If a
+  future runtime has no notion of providers, it should not have to stub them. This
+  split is the most useful thing the interface makes visible.
+- **Event type names stay as-is for now** (`message.part.updated` etc. live behind
+  a normalized `RuntimeEvent` alias). Renaming is a later, separate decision.
+
+## Relationship to ACP (v0.4.0 #14)
+
+[Agent Client Protocol](https://github.com/agentclientprotocol/agent-client-protocol)
+(Zed, Aug 2025; JSON-RPC over stdio; "LSP for agents") is an emerging standard
+for *editors driving agents*. Upstream already lists ACP under v0.4.0.
+
+This RFC is **complementary, not competing**:
+
+- ACP standardizes the **editor → agent** direction (an external editor drives our
+  runtime). That is an *additive* surface — "Open Science as a runtime others can
+  drive."
+- `AgentRuntime` standardizes the **app UI → runtime** direction *internally*. That
+  is the seam *we already rely on*.
+
+The two are orthogonal. But if/when ACP lands, a clean internal boundary means the
+ACP adapter can target `AgentRuntime` (or sit beside it) without `lib/runtime.ts`
+being rewritten around OpenCode specifics. Naming the boundary *before* ACP work
+starts is the main timing argument.
+
+## Phased rollout (each step independently mergeable)
+
+| Phase | Change | Risk | Reversible |
+| --- | --- | --- | --- |
+| **0** (this RFC) | Discussion only. Document the seam, agree on the method set. | None | N/A |
+| **1** | Add `interface AgentRuntime`; `OpenCodeClient implements AgentRuntime`. `lib/runtime.ts` types against the interface, still constructed as `new OpenCodeClient(...)`. No behavior change. | Trivial | Yes |
+| **2** | Decide event-name neutralization: alias OpenCode wire names behind `RuntimeEvent`. | Low | Yes |
+| **3** (future, out of scope) | A second runtime, ACP adapter, or a "custom endpoint" provider — only if a concrete need appears. | — | — |
+
+**Phase 1 is the entire ask behind this RFC.** Phases 2–3 are listed so reviewers
+see the trajectory and can object early.
+
+## Open questions (what I want from discussion)
+
+1. **Method-set agreement.** Are the 15 methods above the right *minimal* contract,
+   or should provider/MCP config be in-scope (i.e., every runtime is expected to
+   expose providers)?
+2. **ACP alignment.** Should the event shape deliberately mirror ACP's session/
+   message/part model now, to make a future adapter cheap — or keep OpenCode's
+   shape and reconcile later?
+3. **Naming & location.** `AgentRuntime` in `packages/sdk/src/runtime.ts`? Or a
+   `packages/runtime-contract` to signal it is shared, not SDK-owned?
+4. **Timing.** Land Phase 1 before v0.4.0 ACP work starts, or fold it into #14?
+5. **Testing the seam.** Would a mock `AgentRuntime` (the SDK already ships
+   `mockServer.ts`) become the basis for frontend tests without a sidecar?
+
+## Alternatives considered
+
+- **Status quo (do nothing).** Valid; the app works. Cost: the v0.4.0 ACP and
+  LAN-surface work will re-litigate "what is runtime-specific" inside a 1.6k-line
+  store file, with no named contract to anchor on.
+- **Build a second runtime now.** Explicitly rejected — no demonstrated need, and
+  it would invert the "extract what exists" principle into "design for an imagined
+  second implementation."
+- **Adopt ACP as the internal boundary.** Rejected for now: ACP is editor-facing
+  and still maturing; our internal seam predates it and serves a different
+  direction. Worth revisiting once #14 ships.
+
+## Timing
+
+This RFC targets the window **after v0.2.1/v0.3.0 and before v0.4.0 ACP work
+begins** — the moment where naming the seam is cheapest and most useful. It is not
+a v0.3.0 deliverable and should not delay UX work tracked in #20–#22.
+
+## References
+
+- `AGENTS.md` — "The UI never calls OpenCode directly — it goes through
+  `packages/sdk`."
+- `docs/PRD.md` §10.3 — "Frontend, desktop shell, and agent runtime decoupled."
+- `docs/TECHNICAL_DESIGN.md` §5 — OpenCode as bundled sidecar; `OpenCodeClient`.
+- Upstream roadmap: v0.4.0 "Agent Client Protocol (ACP) support" (#14), LAN web UI
+  (#3), messaging integrations (#20).
+- [Agent Client Protocol](https://github.com/agentclientprotocol/agent-client-protocol)

--- a/packages/sdk/src/OpenCodeClient.ts
+++ b/packages/sdk/src/OpenCodeClient.ts
@@ -21,6 +21,7 @@ import type {
   ToolCallStatus,
 } from "./types";
 import { DEFAULT_OPENCODE_URL } from "./types";
+import type { AgentRuntime } from "./runtime";
 
 type EventListener = (event: OpenCodeEvent) => void;
 type StatusListener = (status: RuntimeStatus) => void;
@@ -51,7 +52,7 @@ function errorText(error: unknown): string | undefined {
  * Talks to a running `opencode serve` over its HTTP + SSE API. The UI must go
  * through this class, never the transport directly (see AGENTS.md guardrails).
  */
-export class OpenCodeClient {
+export class OpenCodeClient implements AgentRuntime {
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof fetch;
   private readonly authHeader: string | null;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { OpenCodeClient } from "./OpenCodeClient";
+export type { AgentRuntime } from "./runtime";
 export {
   OPENCODE_VERSION,
   DEFAULT_OPENCODE_URL,

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -1,0 +1,71 @@
+import type {
+  AgentInfo,
+  CommandInfo,
+  HistoryMessage,
+  OpenCodeEvent,
+  PermissionAskedEvent,
+  PermissionReply,
+  QuestionAskedEvent,
+  RuntimeStatus,
+  SessionMeta,
+  SkillInfo,
+} from "./types";
+
+/**
+ * The runtime-agnostic boundary between the app UI and the agent runtime.
+ *
+ * `AGENTS.md` mandates that the UI never calls OpenCode directly — it goes
+ * through `packages/sdk`. This interface makes that seam explicit: it covers
+ * ONLY the surface a generic agent runtime must expose (lifecycle, sessions,
+ * capability discovery, model selection, and interactive requests).
+ *
+ * Provider / MCP / OAuth configuration is deliberately OUT of scope — those are
+ * configuration of a specific runtime (OpenCode today), not of "an agent
+ * runtime" in general. Callers that need them go through the concrete
+ * `OpenCodeClient` (e.g. `getClient()`), which `implements AgentRuntime`.
+ *
+ * See `docs/rfc/agent-runtime.md` for the rationale. The sole implementation
+ * today is `OpenCodeClient`; no second runtime is planned. This is Phase 1 —
+ * formalize the seam, change no behavior.
+ */
+export interface AgentRuntime {
+  // ---- lifecycle ----
+  connect(): Promise<void>;
+  close(): void;
+  getStatus(): RuntimeStatus;
+  onStatus(listener: (status: RuntimeStatus) => void): () => void;
+  onEvent(listener: (event: OpenCodeEvent) => void): () => void;
+
+  // ---- sessions (a conversation) ----
+  createSession(): Promise<string>;
+  listSessions(): Promise<SessionMeta[]>;
+  deleteSession(sessionId: string): Promise<void>;
+  getMessages(sessionId: string): Promise<HistoryMessage[]>;
+  sendPrompt(sessionId: string, text: string): Promise<void>;
+  abortSession(sessionId: string): Promise<void>;
+
+  // ---- capability discovery (what this runtime can do) ----
+  listSkills(): Promise<SkillInfo[]>;
+  listAgents(): Promise<AgentInfo[]>;
+  listCommands(): Promise<CommandInfo[]>;
+
+  // ---- model selection ----
+  getDefaultModel(): Promise<string | null>;
+  setDefaultModel(model: string): Promise<void>;
+
+  // ---- agent-driven execution (a full turn, not a single prompt) ----
+  /** Run a shell command in the session's workspace; no model turn. */
+  runShell(sessionId: string, command: string, agent?: string): Promise<void>;
+  /** Run a slash command (config command / skill / MCP prompt) as a full turn. */
+  runCommand(sessionId: string, command: string, args?: string): Promise<void>;
+
+  // ---- interactive requests (the agent asks; the user must answer) ----
+  /** Pending questions in the workspace (recovery on open). */
+  listQuestions(sessionId?: string): Promise<QuestionAskedEvent[]>;
+  /** Pending permission requests in the workspace (recovery on open). */
+  listPermissions(sessionId?: string): Promise<PermissionAskedEvent[]>;
+  answerQuestion(requestId: string, answers: string[][]): Promise<void>;
+  rejectQuestion(requestId: string): Promise<void>;
+  /** Reply to a permission request: allow once, allow always, or reject. */
+  replyPermission(requestId: string, reply: PermissionReply): Promise<void>;
+}


### PR DESCRIPTION
## Update (Phase 1 now implemented)

This PR started as discussion-only. Based on the premise that formalizing the
seam is *cheap and nearly free*, **Phase 1 is now implemented in this PR** —
the interface exists, `OpenCodeClient` implements it, and the store types
against it. No behavior change. Phases 2–3 remain open for discussion.

`docs/rfc/agent-runtime.md` carries the full rationale; the commit
\`feat(sdk): implement AgentRuntime interface boundary\` is the code.

## What this is

Formalizing the seam the app already depends on — `packages/sdk` as *the*
boundary between UI and agent runtime (`AGENTS.md`) — as a small,
runtime-agnostic **\`AgentRuntime\` interface** that \`OpenCodeClient\` implements.

**No second runtime, no user-facing switch, no behavior change.** YAGNI-safe:
we extract *what already exists*.

Full proposal: [\`docs/rfc/agent-runtime.md\`](https://github.com/encyc/open-science/blob/docs/rfc-agent-runtime/docs/rfc/agent-runtime.md).

## What changed (Phase 1)

| File | Change |
| --- | --- |
| \`packages/sdk/src/runtime.ts\` (new) | \`interface AgentRuntime\` — lifecycle, sessions, discovery, model selection, agent-driven execution, interactive requests. Provider/MCP/OAuth deliberately out of scope. |
| \`packages/sdk/src/OpenCodeClient.ts\` | \`OpenCodeClient implements AgentRuntime\` (+ type-only import). |
| \`packages/sdk/src/index.ts\` | Export \`AgentRuntime\`. |
| \`apps/desktop/src/lib/runtime.ts\` | Internal \`client\` typed as \`AgentRuntime\`; a concrete \`opencodeClient\` backs \`getClient()\` so Settings/setup keep the full provider/MCP surface. |

Net: **+102 / −13 across 5 files.** The interface is derived from the runtime
methods \`lib/runtime.ts\` already calls (verified by grep) — nothing invented.

## Verification

- ✅ \`pnpm typecheck\` green (interface signatures match \`OpenCodeClient\` exactly — \`implements\` would fail otherwise)
- ✅ \`pnpm lint\` green
- ✅ \`opencode-client.node.test.ts\` 16/16 green (exercises \`new OpenCodeClient()\` connect → createSession → sendPrompt → streaming end to end against a mock server)
- ⚠️ The broader \`pnpm test\` suite has a pre-existing failure (\`window.localStorage.getItem is not a function\` in the jsdom test setup, unrelated to this change) — confirmed identical on clean \`master\` via \`git stash\`.

## Key design decisions

1. **Provider/MCP/OAuth methods are excluded from the interface.** They are
   *configuration of OpenCode-the-implementation*, not of "an agent runtime" in
   general. \`getClient()\` still returns the concrete \`OpenCodeClient\` for
   Settings/setup, which need that surface. The interface stays minimal.
2. **ACP is complementary, not competing.** [ACP](https://github.com/agentclientprotocol/agent-client-protocol)
   standardizes the **editor → agent** direction (an external editor drives our
   runtime — upstream #14). \`AgentRuntime\` standardizes the **app UI → runtime**
   direction *internally*. Orthogonal — but naming the internal boundary *before*
   ACP work starts means the adapter can target it without \`lib/runtime.ts\`
   being rewritten around OpenCode specifics.

## Open questions for discussion (Phases 2–3)

1. **Method set** — is the current interface the right *minimal* contract, or
   should provider/MCP config be in-scope?
2. **ACP alignment (Phase 2)** — should the event shape deliberately mirror
   ACP's session/message/part model now, or keep OpenCode's shape and reconcile
   later?
3. **Location** — \`AgentRuntime\` in \`packages/sdk\`, or a new
   \`packages/runtime-contract\`?
4. **Timing** — land now (before v0.4.0 ACP work), or fold into #14?
5. **Mock runtime** — should the SDK's existing \`mockServer.ts\` become the
   basis for frontend tests without a sidecar?

Happy to split this into two PRs (RFC doc vs. impl) if reviewers prefer to land
them separately.

cc — relevant to #14 (ACP), #3 (LAN UI), #20 (messaging).