### PR TITLE
feat(desktop): Improve permission request notifications

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "docx-preview": "^0.3.7",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tokio",
@@ -2165,6 +2166,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +2326,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -2862,6 +2891,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,6 +3008,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3937,6 +4004,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,6 +4156,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 # macos-private-api: transparent webview background for the vibrancy sidebar
 # (tauri.macos.conf.json); no-op on other platforms.
-tauri = { version = "2", features = ["macos-private-api"] }
+tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
@@ -24,6 +24,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["time"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-notification = "2"
 getrandom = "0.4.3"
 opener = { version = "0.8.5", features = ["reveal"] }
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-set-theme",
     "core:webview:allow-set-webview-zoom",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "notification:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -46,6 +46,7 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_notification::init())
         .manage(RuntimeState::default())
         .manage(KernelState::default())
         .manage(JupyterState::default())

--- a/apps/desktop/src/lib/runtime.store.test.ts
+++ b/apps/desktop/src/lib/runtime.store.test.ts
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => ({
     mocks.approvalMode = mode;
     return "http://127.0.0.1:1";
   }),
+  notifyPermissionRequest: vi.fn(async () => true),
   startRuntime: vi.fn(async () => "http://127.0.0.1:1"),
   /** Constructor options every OpenCodeClient was created with. */
   clientOpts: [] as Record<string, unknown>[],
@@ -65,6 +66,9 @@ vi.mock("./tauri", () => ({
   runtimePassword: async () => "pw-test",
 }));
 vi.mock("./kernel", () => ({ kernelReset: mocks.kernelReset }));
+vi.mock("./systemNotification", () => ({
+  notifyPermissionRequest: mocks.notifyPermissionRequest,
+}));
 vi.mock("@ai4s/sdk", () => {
   class OpenCodeClient {
     private statusCb: (s: string) => void = () => {};
@@ -190,6 +194,7 @@ beforeEach(async () => {
   mocks.approvalMode = "approve";
   mocks.currentModel = null;
   mocks.failSetModel = false;
+  mocks.notifyPermissionRequest.mockResolvedValue(true);
   useRuntimeStore.setState({
     currentId: null,
     workspacePinned: false,
@@ -578,6 +583,26 @@ describe("subagent permission asks and long sync turns", () => {
     expect(mocks.replyPermission).toHaveBeenCalledTimes(3);
     expect(mocks.replyPermission).toHaveBeenCalledWith("per_b", "always");
     expect(useRuntimeStore.getState().permissions).toHaveLength(0);
+  });
+
+  it("sends one system notification for each new permission request", async () => {
+    await useRuntimeStore.getState().sendPrompt("go");
+    const permission = {
+      type: "permission.asked" as const,
+      sessionId: "ses_new",
+      requestId: "per_notify",
+      action: "bash",
+      resources: ["npm install"],
+    };
+
+    mocks.fireEvent(permission);
+    mocks.fireEvent(permission);
+
+    expect(mocks.notifyPermissionRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.notifyPermissionRequest).toHaveBeenCalledWith({
+      action: "bash",
+      resources: ["npm install"],
+    });
   });
 });
 

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -41,6 +41,7 @@ import { deriveArtifact } from "./artifacts";
 import { provenanceInputFromEvent, recordProvenance } from "./provenance";
 import { recordRun, runInputFromEvent } from "./runs";
 import { splitReview } from "./review";
+import { notifyPermissionRequest } from "./systemNotification";
 import i18n from "@/i18n";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -228,6 +229,7 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 const recordedProvenance = new Set<string>();
 /** Bash calls already written to the run store — terminal events can repeat per callId. */
 const recordedRuns = new Set<string>();
+const notifiedPermissions = new Set<string>();
 
 /** Sessions the user just interrupted: the thread already shows "Interrupted",
  *  so the abort's own trailing events (an "aborted" error and one or more
@@ -732,6 +734,10 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
           set((s) => ({ questions: s.questions.filter((q) => q.requestId !== event.requestId) }));
           return;
         case "permission.asked":
+          if (!notifiedPermissions.has(event.requestId)) {
+            notifiedPermissions.add(event.requestId);
+            void notifyPermissionRequest({ action: event.action, resources: event.resources });
+          }
           set((s) => ({
             permissions: [
               ...s.permissions.filter((p) => p.requestId !== event.requestId),

--- a/apps/desktop/src/lib/systemNotification.test.ts
+++ b/apps/desktop/src/lib/systemNotification.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { notifyPermissionRequest } from "./systemNotification";
+
+const notificationPlugin = vi.hoisted(() => ({
+  isPermissionGranted: vi.fn(async () => true),
+  requestPermission: vi.fn(async () => "granted"),
+  sendNotification: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-notification", () => notificationPlugin);
+
+describe("notifyPermissionRequest", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    notificationPlugin.isPermissionGranted.mockResolvedValue(true);
+    notificationPlugin.requestPermission.mockResolvedValue("granted");
+  });
+
+  it("sends a native Tauri notification when permission is already granted", async () => {
+    await expect(
+      notifyPermissionRequest({ action: "bash", resources: ["npm install"] }),
+    ).resolves.toBe(true);
+
+    expect(notificationPlugin.requestPermission).not.toHaveBeenCalled();
+    expect(notificationPlugin.sendNotification).toHaveBeenCalledWith({
+      title: "Open Science needs your approval",
+      body: "bash\nnpm install",
+    });
+  });
+
+  it("requests native notification permission before sending", async () => {
+    notificationPlugin.isPermissionGranted.mockResolvedValue(false);
+    notificationPlugin.requestPermission.mockResolvedValue("granted");
+
+    await expect(
+      notifyPermissionRequest({ action: "webfetch", resources: ["https://example.com"] }),
+    ).resolves.toBe(true);
+
+    expect(notificationPlugin.requestPermission).toHaveBeenCalledTimes(1);
+    expect(notificationPlugin.sendNotification).toHaveBeenCalledWith({
+      title: "Open Science needs your approval",
+      body: "webfetch\nhttps://example.com",
+    });
+  });
+
+  it("does not notify when native notification permission is denied", async () => {
+    notificationPlugin.isPermissionGranted.mockResolvedValue(false);
+    notificationPlugin.requestPermission.mockResolvedValue("denied");
+
+    await expect(
+      notifyPermissionRequest({ action: "bash", resources: ["rm -rf build/"] }),
+    ).resolves.toBe(false);
+
+    expect(notificationPlugin.sendNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/systemNotification.ts
+++ b/apps/desktop/src/lib/systemNotification.ts
@@ -1,0 +1,33 @@
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
+
+export interface PermissionNotificationInput {
+  action: string;
+  resources: string[];
+}
+
+function permissionBody(input: PermissionNotificationInput): string {
+  const firstResource = input.resources[0];
+  return firstResource ? `${input.action}\n${firstResource}` : input.action;
+}
+
+export async function notifyPermissionRequest(input: PermissionNotificationInput): Promise<boolean> {
+  let granted = await isPermissionGranted();
+  if (!granted) {
+    granted = (await requestPermission()) === "granted";
+  }
+  if (!granted) return false;
+
+  try {
+    sendNotification({
+      title: "Open Science needs your approval",
+      body: permissionBody(input),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.2
         version: 2.3.2
+      '@tauri-apps/plugin-notification':
+        specifier: ^2.3.3
+        version: 2.3.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1220,6 +1223,9 @@ packages:
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4178,6 +4184,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
       '@tauri-apps/api': 2.11.1
 


### PR DESCRIPTION
## Summary

Implements ai4s-research/open-science#21.

- Add native Tauri notifications when an agent permission request is waiting for user approval.
- Keep the existing in-app permission card as the approval surface for Allow once / Always allow / Reject.
- Add tests for native notification behavior and runtime permission-event integration.

## Motivation

This implements the requested enhancement for surfacing permission requests outside the app window. Previously, permission requests were only visible in the in-app prompt. If the user was focused on another window, they could miss that the agent was blocked waiting for approval.

The notification is only a reminder; approval decisions still happen through the existing in-app permission card.

## Implementation notes

- Adds `@tauri-apps/plugin-notification` and `tauri-plugin-notification`.
- Registers the Tauri notification plugin in the desktop shell.
- Adds `notification:default` to the desktop capability.
- Sends a native notification when a new `permission.asked` event is received.
- Deduplicates notifications by permission request id.
- Does not auto-approve permissions or change the existing permission policy.

## Test plan

- [x] `pnpm --filter @ai4s/desktop test -- src/lib/systemNotification.test.ts src/lib/runtime.store.test.ts`
- [x] `pnpm --filter @ai4s/desktop typecheck`
- [x] `pnpm --filter @ai4s/desktop lint`
- [x] `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`
- [x] Manual Windows verification: triggered a permission request with `curl --version`; native notification appeared and the in-app permission card remained the approval surface
- [ ] macOS notification display not locally verified
- [ ] Linux notification display not locally verified

Implements and closes ai4s-research/open-science#21.