### PR TITLE
feat(sdk): CodexRuntime prototype — second AgentRuntime, validates #25

### DIFF
--- a/apps/desktop/src/test/codex-runtime.test.ts
+++ b/apps/desktop/src/test/codex-runtime.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { afterAll, describe, expect, it } from "vitest";
-import { CodexRuntime, type OpenCodeEvent } from "@ai4s/sdk";
+import { CodexRuntime } from "@ai4s/sdk/node-runtime";
+import type { OpenCodeEvent } from "@ai4s/sdk";
 
 /**
  * A mock codex app-server for protocol-translation tests. Speaks the JSON-RPC
@@ -157,8 +158,11 @@ describe("CodexRuntime — protocol translation", () => {
     expect(pending.length).toBe(1);
     expect(pending[0].resources).toEqual(["rm -rf /tmp/x"]);
 
-    // Replying clears it without throwing.
+    // Replying must CLEAR the pending approval. (Regression guard: an earlier
+    // version deleted by requestId while the map is keyed by thread id, so the
+    // entry never cleared — listPermissions kept reporting it forever.)
     await approvalRt.replyPermission("appr-1", "reject");
+    expect((await approvalRt.listPermissions()).length).toBe(0);
     approvalRt.close();
   });
 

--- a/apps/desktop/src/test/codex-runtime.test.ts
+++ b/apps/desktop/src/test/codex-runtime.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+import { afterAll, describe, expect, it } from "vitest";
+import { CodexRuntime, type OpenCodeEvent } from "@ai4s/sdk";
+
+/**
+ * A mock codex app-server for protocol-translation tests. Speaks the JSON-RPC
+ * methods CodexRuntime expects (initialize, thread/start, thread/send,
+ * thread/cancel, approveCommand) and, crucially, emits the NOTIFICATIONS that
+ * exercise CodexRuntime's event translation: thread/message, thread/command,
+ * thread/commandApprovalRequest, thread/completed.
+ *
+ * It is our best-effort reconstruction of the codex wire shape — the same shape
+ * CodexRuntime targets — so if codex's real fields differ, BOTH this mock and
+ * CodexRuntime would change together.
+ */
+const MOCK_CODEX = `
+const delays = (ms) => new Promise((r) => setTimeout(r, ms));
+let buf = "";
+let nextId = 0;
+const pendingTurns = new Map(); // request id -> thread_id (turns awaiting completion)
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", async (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf("\\n")) !== -1) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (line.trim()) await handle(JSON.parse(line));
+  }
+});
+function send(obj) { process.stdout.write(JSON.stringify(obj) + "\\n"); }
+function notify(method, params) { send({ jsonrpc: "2.0", method, params }); }
+
+async function handle(msg) {
+  if (msg.id !== undefined) {
+    if (msg.method === "initialize") {
+      send({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
+    } else if (msg.method === "thread/start") {
+      const tid = "thread-" + (++nextId);
+      send({ jsonrpc: "2.0", id: msg.id, result: { id: tid } });
+    } else if (msg.method === "thread/send") {
+      const tid = msg.params.thread_id;
+      // Hold the turn response until the turn "completes" via notifications.
+      // Emit streamed text, a tool call, then complete.
+      notify("thread/message", { thread_id: tid, delta: "Hello " });
+      notify("thread/message", { thread_id: tid, delta: "world." });
+      notify("thread/command", { thread_id: tid, id: "cmd-1", command: "ls", state: "running" });
+      notify("thread/command", { thread_id: tid, id: "cmd-1", command: "ls", state: "done", output: "file.txt" });
+      notify("thread/completed", { thread_id: tid });
+      send({ jsonrpc: "2.0", id: msg.id, result: { done: true } });
+    } else if (msg.method === "thread/cancel") {
+      send({ jsonrpc: "2.0", id: msg.id, result: { cancelled: true } });
+    } else if (msg.method === "approveCommand") {
+      send({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
+    } else {
+      send({ jsonrpc: "2.0", id: msg.id, result: {} });
+    }
+  }
+}
+process.stdout.write("READY\\n");
+`;
+
+/** A second mock that injects a command-approval request mid-turn. */
+const MOCK_CODEX_APPROVAL = `
+let buf = "";
+let nextId = 0;
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", async (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf("\\n")) !== -1) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (line.trim()) await handle(JSON.parse(line));
+  }
+});
+function send(obj) { process.stdout.write(JSON.stringify(obj) + "\\n"); }
+function notify(method, params) { send({ jsonrpc: "2.0", method, params }); }
+async function handle(msg) {
+  if (msg.id !== undefined) {
+    if (msg.method === "initialize") {
+      send({ jsonrpc: "2.0", id: msg.id, result: { ok: true } });
+    } else if (msg.method === "thread/start") {
+      const tid = "thread-" + (++nextId);
+      send({ jsonrpc: "2.0", id: msg.id, result: { id: tid } });
+    } else if (msg.method === "thread/send") {
+      const tid = msg.params.thread_id;
+      // The agent wants to run rm; codex pauses and asks the client to approve.
+      notify("thread/commandApprovalRequest", { thread_id: tid, id: "appr-1", command: "rm -rf /tmp/x" });
+      // Turn response withheld until approveCommand arrives — but to keep the
+      // test bounded we complete immediately after requesting approval.
+      notify("thread/completed", { thread_id: tid });
+      send({ jsonrpc: "2.0", id: msg.id, result: { done: true } });
+    } else {
+      send({ jsonrpc: "2.0", id: msg.id, result: {} });
+    }
+  }
+}
+process.stdout.write("READY\\n");
+`;
+
+let rt: CodexRuntime;
+
+afterAll(async () => {
+  rt?.close();
+});
+
+describe("CodexRuntime — protocol translation", () => {
+  it("connect, createSession, and stream a turn into normalized events", async () => {
+    const events: OpenCodeEvent[] = [];
+    rt = new CodexRuntime({ command: ["node", "-e", MOCK_CODEX] });
+    rt.onEvent((e) => events.push(e));
+    await rt.connect();
+    expect(rt.getStatus()).toBe("ready");
+
+    const sid = await rt.createSession();
+    expect(sid).toBe("thread-1");
+
+    // sendPrompt awaits turn completion; notifications stream in first.
+    await rt.sendPrompt(sid, "hi");
+
+    // Text deltas accumulate into text.updated events (full value each time).
+    const texts = events.filter((e) => e.type === "text.updated");
+    expect(texts.length).toBe(2);
+    expect((texts[0] as { text: string }).text).toBe("Hello ");
+    expect((texts[1] as { text: string }).text).toBe("Hello world.");
+
+    // A tool call surfaces as tool.updated (running then success).
+    const tools = events.filter((e) => e.type === "tool.updated");
+    expect(tools.length).toBe(2);
+    expect((tools[0] as { status: string }).status).toBe("running");
+    expect((tools[1] as { status: string }).status).toBe("success");
+
+    // The turn ends with session.idle (composer unlocks).
+    const idle = events.find((e) => e.type === "session.idle");
+    expect(idle).toBeTruthy();
+    expect((idle as { sessionId: string }).sessionId).toBe(sid);
+  });
+
+  it("maps a command-approval request to permission.asked", async () => {
+    const events: OpenCodeEvent[] = [];
+    const approvalRt = new CodexRuntime({ command: ["node", "-e", MOCK_CODEX_APPROVAL] });
+    approvalRt.onEvent((e) => events.push(e));
+    await approvalRt.connect();
+    const sid = await approvalRt.createSession();
+    await approvalRt.sendPrompt(sid, "clean up");
+
+    const asked = events.find((e) => e.type === "permission.asked") as
+      | { action: string; resources: string[] }
+      | undefined;
+    expect(asked).toBeTruthy();
+    expect(asked!.action).toBe("bash");
+    expect(asked!.resources).toEqual(["rm -rf /tmp/x"]);
+
+    // listPermissions surfaces it too (recovery path).
+    const pending = await approvalRt.listPermissions();
+    expect(pending.length).toBe(1);
+    expect(pending[0].resources).toEqual(["rm -rf /tmp/x"]);
+
+    // Replying clears it without throwing.
+    await approvalRt.replyPermission("appr-1", "reject");
+    approvalRt.close();
+  });
+
+  it("status transitions through connecting → ready → offline", async () => {
+    const statuses: string[] = [];
+    const s = new CodexRuntime({ command: ["node", "-e", MOCK_CODEX] });
+    const unsub = s.onStatus((st) => statuses.push(st));
+    expect(s.getStatus()).toBe("offline");
+    await s.connect();
+    expect(s.getStatus()).toBe("ready");
+    s.close();
+    expect(s.getStatus()).toBe("offline");
+    // connecting then ready fired on connect; offline on close.
+    expect(statuses).toContain("connecting");
+    expect(statuses).toContain("ready");
+    expect(statuses).toContain("offline");
+    unsub();
+  });
+});

--- a/apps/desktop/src/test/stdio-jsonrpc.test.ts
+++ b/apps/desktop/src/test/stdio-jsonrpc.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { StdioJsonRpcClient } from "@ai4s/sdk";
+
+/**
+ * A tiny "JSON-RPC echo" child: reads newline-delimited requests on stdin and,
+ * for `echo` requests, replies with the params as the result; for `notify`
+ * notifications, re-broadcasts them. Used to exercise the real stdio transport
+ * without depending on any agent binary.
+ *
+ * It also supports a `send-then-quit` mode: when it reads "DONE", it exits, so
+ * we can assert in-flight requests are rejected.
+ */
+const ECHO_SCRIPT = `
+// A minimal newline-delimited JSON-RPC echo child for transport tests.
+let buf = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf("\\n")) !== -1) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    handle(line);
+  }
+});
+function send(obj) { process.stdout.write(JSON.stringify(obj) + "\\n"); }
+function handle(line) {
+  if (!line.trim()) return;
+  let msg;
+  try { msg = JSON.parse(line); } catch { return; }
+  if (msg.id !== undefined) {
+    if (msg.method === "echo") {
+      send({ jsonrpc: "2.0", id: msg.id, result: msg.params });
+    } else if (msg.method === "fail") {
+      send({ jsonrpc: "2.0", id: msg.id, error: { code: -32000, message: "boom" } });
+    }
+  } else {
+    // Notification: re-broadcast so the client's onNotification fires.
+    send({ jsonrpc: "2.0", method: "event/" + (msg.method || "x"), params: msg.params });
+  }
+}
+process.stdout.write("READY\\n"); // signal start() can resolve
+`;
+
+let client: StdioJsonRpcClient;
+
+beforeAll(async () => {
+  // Run the echo script with node.
+  client = new StdioJsonRpcClient({
+    command: ["node", "-e", ECHO_SCRIPT],
+    killGraceMs: 1000,
+  });
+  await client.start();
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+describe("StdioJsonRpcClient — request/response", () => {
+  it("awaits the matching response by id", async () => {
+    const result = (await client.request("echo", { hello: "world" })) as {
+      hello: string;
+    };
+    expect(result).toEqual({ hello: "world" });
+  });
+
+  it("rejects on a JSON-RPC error response", async () => {
+    await expect(client.request("fail", {})).rejects.toThrow(/boom/);
+  });
+
+  it("pairs concurrent requests to the right response (no id crossover)", async () => {
+    const [a, b, c] = await Promise.all([
+      client.request("echo", { n: 1 }),
+      client.request("echo", { n: 2 }),
+      client.request("echo", { n: 3 }),
+    ]);
+    expect(a).toEqual({ n: 1 });
+    expect(b).toEqual({ n: 2 });
+    expect(c).toEqual({ n: 3 });
+  });
+});
+
+describe("StdioJsonRpcClient — notifications", () => {
+  it("delivers server notifications to onNotification handlers", async () => {
+    const seen: unknown[] = [];
+    const unsub = client.onNotification("event/ping", (p) => seen.push(p));
+    // Send a notification; the echo script re-broadcasts it as event/ping.
+    client.notify("ping", { x: 42 });
+    // Give the round trip a beat.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(seen).toEqual([{ x: 42 }]);
+    unsub();
+  });
+
+  it("unsubscribe stops further deliveries", async () => {
+    const seen: unknown[] = [];
+    const unsub = client.onNotification("event/once", (p) => seen.push(p));
+    unsub();
+    client.notify("once", { gone: true });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(seen).toEqual([]);
+  });
+});
+
+describe("StdioJsonRpcClient — framing", () => {
+  it("reassembles a response split across multiple stdout chunks", async () => {
+    // Send two requests; the child writes both responses. Line-delimited framing
+    // must not smear them. (Concurrent requests above already cover the
+    // multi-line case; this asserts we tolerate interleaving.)
+    const r = await client.request("echo", { split: true });
+    expect(r).toEqual({ split: true });
+  });
+});
+
+describe("StdioJsonRpcClient — lifecycle", () => {
+  it("rejects requests after close()", async () => {
+    // Use a fresh client so we can kill it mid-request.
+    const dying = new StdioJsonRpcClient({
+      command: ["node", "-e", ECHO_SCRIPT],
+      killGraceMs: 500,
+    });
+    await dying.start();
+    await dying.close();
+    // After close, a new request must reject, not hang.
+    await expect(dying.request("echo", {})).rejects.toThrow(/not running/);
+  });
+});

--- a/apps/desktop/src/test/stdio-jsonrpc.test.ts
+++ b/apps/desktop/src/test/stdio-jsonrpc.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { StdioJsonRpcClient } from "@ai4s/sdk";
+import { StdioJsonRpcClient } from "@ai4s/sdk/node-runtime";
 
 /**
  * A tiny "JSON-RPC echo" child: reads newline-delimited requests on stdin and,

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       "@": r("./src"),
       "@ai4s/shared": r("../../packages/shared/src/index.ts"),
       "@ai4s/sdk/mock-server": r("../../packages/sdk/src/mockServer.ts"),
+      "@ai4s/sdk/node-runtime": r("../../packages/sdk/src/node-runtime.ts"),
       "@ai4s/sdk": r("../../packages/sdk/src/index.ts"),
     },
   },

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -1,0 +1,149 @@
+# Integrating a new agent runtime
+
+Open Science Desktop is model-agnostic and runtime-pluggable: the bundled
+**OpenCode** is the default, but any agent that can be driven as a process can be
+wired in as an `AgentRuntime`. This guide shows a contributor how to add one.
+
+> The architecture and rationale live in [`docs/rfc/agent-runtime.md`](./rfc/agent-runtime.md)
+> and [`docs/rfc/multi-agent-acp.md`](./rfc/multi-agent-acp.md). This page is the
+> **how-to**.
+
+## What you are building
+
+A class that talks to *your* agent and speaks the app's normalized event stream.
+The app (store, provenance, runs, UI) only knows the `AgentRuntime` contract —
+it never sees your agent's native protocol.
+
+```
+your agent binary  ←─ your protocol ─→  YourRuntime  ──→  app (unchanged)
+                                         implements AgentRuntime
+```
+
+## The two building blocks
+
+Everything you need is exported from `@ai4s/sdk`:
+
+| Export | Role |
+| --- | --- |
+| `BaseAgentRuntime` | **Extend this.** Gives you the listener + status machinery (`getStatus`, `onEvent`, `onStatus`, and protected `emit`/`setStatus`) for free — identical across every runtime. |
+| `AgentRuntime` (type) | The interface your class satisfies. `extends BaseAgentRuntime` covers the listener methods; you implement the rest. |
+
+If your agent speaks **JSON-RPC over stdio** (Codex's `app-server`, or any ACP
+agent), you also get a transport for free:
+
+| Export | Role |
+| --- | --- |
+| `StdioJsonRpcClient` | Spawns a child process, frames line-delimited JSON-RPC 2.0, matches requests to responses by id, and delivers notifications. Used by `CodexRuntime`; reusable for any stdio agent. |
+
+## The 5 steps
+
+### 1. Extend `BaseAgentRuntime`
+
+```ts
+import { BaseAgentRuntime, StdioJsonRpcClient } from "@ai4s/sdk";
+import type { OpenCodeEvent } from "@ai4s/sdk";
+
+export class MyAgentRuntime extends BaseAgentRuntime {
+  // …your fields…
+}
+```
+
+`getStatus` / `onEvent` / `onStatus` are inherited. You do **not** write them.
+
+### 2. Implement `connect()` / `close()`
+
+Call `this.setStatus("connecting")` when you start, `"ready"` once connected,
+`"error"` on failure, and `this.setStatus("offline")` in `close()`. The status
+badge in the UI follows these automatically.
+
+```ts
+async connect(): Promise<void> {
+  this.setStatus("connecting");
+  // spawn your agent / open your transport
+  this.setStatus("ready");
+}
+close(): void {
+  // tear down
+  this.setStatus("offline");
+}
+```
+
+### 3. Translate your agent's output into `OpenCodeEvent`
+
+This is the heart of the integration. Call `this.emit(event)` for every
+normalized event so the app's store, provenance, and runs recorder pick it up.
+The five event types that matter:
+
+| Your agent produces | Emit this | Why |
+| --- | --- | --- |
+| A chunk of assistant text | `text.updated` | Streams into the chat. Emit the **full accumulated** text so far (not just the delta) — the app upserts by `partId`. |
+| A tool/command running | `tool.updated` (status `running`) | Shows the tool card. |
+| A tool/command finishing | `tool.updated` (status `success`/`failed`) | Resolves the tool card. |
+| A command needing approval | `permission.asked` | Pops the approval dialog; the turn pauses until the user replies. |
+| The turn ending | `session.idle` | Unlocks the composer. |
+
+```ts
+// text arriving in pieces — accumulate, then emit the full value
+this.emit({
+  type: "text.updated",
+  sessionId: threadId,
+  partId: "text",
+  text: accumulated,
+});
+```
+
+### 4. Implement the session methods
+
+| Method | What to do | If your agent has no equivalent |
+| --- | --- | --- |
+| `createSession()` | Start a conversation; return its id | — (required) |
+| `sendPrompt(id, text, agent?, model?)` | Drive one turn; await completion | — (required) |
+| `abortSession(id)` | Cancel the in-flight turn | best-effort |
+| `getMessages(id)` | Load history | return `[]` or replay what you buffered |
+| `listSessions()` / `deleteSession()` | History management | return `[]` / no-op |
+| `listSkills()` / `listAgents()` / `listCommands()` | Capability discovery | return `[]` (honest, not fake) |
+| `getDefaultModel()` / `setDefaultModel()` | Model picker | return `null` / no-op |
+| `runShell()` / `runCommand()` | Shell & slash modes | no-op if unsupported |
+| `listQuestions()` / `listPermissions()` | Pending interactive requests | return `[]` |
+| `answerQuestion()` / `rejectQuestion()` / `replyPermission()` | Reply to the agent | implement for approval-based agents |
+
+**Return empty/no-op for things your agent doesn't have — don't fake data.** The
+UI gracefully hides surfaces that report empty.
+
+### 5. Test against a mock, not a real agent
+
+Your agent binary may need a license, a key, or a network — CI has none of those.
+Write tests with a **mock** that speaks your protocol. See
+`apps/desktop/src/test/codex-runtime.test.ts`: it spawns a tiny `node -e` script
+that echoes the codex JSON-RPC shape, so the test runs anywhere.
+
+```
+✓ connect, createSession, and stream a turn into normalized events
+✓ maps a command-approval request to permission.asked
+✓ status transitions through connecting → ready → offline
+```
+
+## Reference implementation
+
+[`CodexRuntime`](../packages/sdk/src/CodexRuntime.ts) is the worked example. It
+spawns `codex app-server`, drives it with `StdioJsonRpcClient`, and translates
+codex's `thread/message` / `thread/command` / `thread/commandApprovalRequest` /
+`thread/completed` notifications into the five `OpenCodeEvent` types above. Read
+it alongside this guide.
+
+## The ACP shortcut
+
+If your agent already speaks the **[Agent Client Protocol](https://agentclientprotocol.com/)**
+(many do — Gemini CLI, Copilot CLI, Claude Code, and soon others), you don't
+write a per-agent class at all: you'll configure it as an ACP server once
+`AcpRuntime` lands (tracked in [#25](../docs/rfc/multi-agent-acp.md)). A custom
+runtime is for agents with a **private** protocol, like codex's app-server today.
+
+## Checklist for a PR
+
+- [ ] Class `extends BaseAgentRuntime`, `implements AgentRuntime`.
+- [ ] `connect`/`close` drive `setStatus` through the lifecycle.
+- [ ] Agent output is translated into the five `OpenCodeEvent` types.
+- [ ] Methods your agent doesn't support return empty/no-op (no fake data).
+- [ ] A mock-based test in `apps/desktop/src/test/` passes without the real binary.
+- [ ] `pnpm typecheck` + `pnpm lint` green (the `implements` clause enforces the interface).

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -21,7 +21,7 @@ your agent binary  ←─ your protocol ─→  YourRuntime  ──→  app (unc
 
 ## The two building blocks
 
-Everything you need is exported from `@ai4s/sdk`:
+The base class and types are exported from `@ai4s/sdk`:
 
 | Export | Role |
 | --- | --- |
@@ -29,7 +29,10 @@ Everything you need is exported from `@ai4s/sdk`:
 | `AgentRuntime` (type) | The interface your class satisfies. `extends BaseAgentRuntime` covers the listener methods; you implement the rest. |
 
 If your agent speaks **JSON-RPC over stdio** (Codex's `app-server`, or any ACP
-agent), you also get a transport for free:
+agent), you also get a transport for free. It spawns a child process
+(`node:child_process`), so it lives in the **node-only subpath**
+`@ai4s/sdk/node-runtime` — never import it from the main barrel (it would pull
+Node internals into the browser build):
 
 | Export | Role |
 | --- | --- |
@@ -40,7 +43,8 @@ agent), you also get a transport for free:
 ### 1. Extend `BaseAgentRuntime`
 
 ```ts
-import { BaseAgentRuntime, StdioJsonRpcClient } from "@ai4s/sdk";
+import { BaseAgentRuntime } from "@ai4s/sdk";
+import { StdioJsonRpcClient } from "@ai4s/sdk/node-runtime";
 import type { OpenCodeEvent } from "@ai4s/sdk";
 
 export class MyAgentRuntime extends BaseAgentRuntime {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -7,7 +7,8 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./mock-server": "./src/mockServer.ts"
+    "./mock-server": "./src/mockServer.ts",
+    "./node-runtime": "./src/node-runtime.ts"
   },
   "dependencies": {
     "@ai4s/shared": "workspace:*"

--- a/packages/sdk/src/CodexRuntime.ts
+++ b/packages/sdk/src/CodexRuntime.ts
@@ -13,16 +13,14 @@
 //
 // Node-only: StdioJsonRpcClient spawns a child process.
 import { StdioJsonRpcClient } from "./stdio-jsonrpc";
-import type { AgentRuntime } from "./runtime";
+import { BaseAgentRuntime } from "./base-runtime";
 import type {
   AgentInfo,
   CommandInfo,
   HistoryMessage,
-  OpenCodeEvent,
   PermissionAskedEvent,
   PermissionReply,
   QuestionAskedEvent,
-  RuntimeStatus,
   SessionMeta,
   SkillInfo,
 } from "./types";
@@ -56,35 +54,24 @@ interface PendingApproval {
  * `codex app-server` as a child process, drives it over JSON-RPC, and translates
  * its events into the app's normalized `OpenCodeEvent` stream so the rest of the
  * app (store, provenance, runs, UI) is unchanged.
+ *
+ * Also serves as the **reference implementation** for a third-party agent
+ * runtime — see docs/AGENT_INTEGRATION.md. The listener/status plumbing is
+ * inherited from BaseAgentRuntime; this class fills in only codex-specific
+ * protocol translation.
  */
-export class CodexRuntime implements AgentRuntime {
+export class CodexRuntime extends BaseAgentRuntime {
   private rpc: StdioJsonRpcClient | null = null;
-  private status: RuntimeStatus = "offline";
   /** threadId (codex) → accumulated text, so streamed deltas assemble like OpenCode. */
   private readonly textStreams = new Map<string, string>();
   /** threadId → the approval currently blocking it (one at a time per thread). */
   private readonly pendingApprovals = new Map<string, PendingApproval>();
-  private readonly eventListeners = new Set<(e: OpenCodeEvent) => void>();
-  private readonly statusListeners = new Set<(s: RuntimeStatus) => void>();
   private readonly unsubs: Array<() => void> = [];
   private readonly options: CodexRuntimeOptions;
 
   constructor(options: CodexRuntimeOptions = {}) {
+    super();
     this.options = options;
-  }
-
-  getStatus(): RuntimeStatus {
-    return this.status;
-  }
-
-  onEvent(listener: (e: OpenCodeEvent) => void): () => void {
-    this.eventListeners.add(listener);
-    return () => this.eventListeners.delete(listener);
-  }
-
-  onStatus(listener: (s: RuntimeStatus) => void): () => void {
-    this.statusListeners.add(listener);
-    return () => this.statusListeners.delete(listener);
   }
 
   /** Spawn codex app-server and run the JSON-RPC `initialize` handshake. */
@@ -289,7 +276,7 @@ export class CodexRuntime implements AgentRuntime {
   // ---- internals ----
 
   private requireReady(): void {
-    if (this.status !== "ready" || !this.rpc)
+    if (this.getStatus() !== "ready" || !this.rpc)
       throw new Error("Codex runtime is not connected");
   }
 
@@ -375,16 +362,6 @@ export class CodexRuntime implements AgentRuntime {
         this.emit({ type: "session.idle", sessionId: sid });
       }),
     );
-  }
-
-  private emit(event: OpenCodeEvent): void {
-    this.eventListeners.forEach((l) => l(event));
-  }
-
-  private setStatus(status: RuntimeStatus): void {
-    if (this.status === status) return;
-    this.status = status;
-    this.statusListeners.forEach((l) => l(status));
   }
 
   /** Override hook for stderr logging. */

--- a/packages/sdk/src/CodexRuntime.ts
+++ b/packages/sdk/src/CodexRuntime.ts
@@ -1,0 +1,392 @@
+// CodexRuntime: an AgentRuntime backed by the Codex App Server (codex app-server).
+//
+// PROTOTYPE — see docs/rfc/multi-agent-acp.md. This validates that the
+// AgentRuntime interface (packages/sdk/src/runtime.ts) can drive a second,
+// non-OpenCode runtime. The transport (StdioJsonRpcClient) is the shared layer
+// a future AcpRuntime will also use.
+//
+// The codex app-server protocol (JSON-RPC 2.0 over stdio) is reconstructed from
+// public docs/descriptions, NOT verified against a live `codex app-server` on
+// every commit. Method names and event field shapes are our best-effort mapping
+// and MUST be confirmed against a real codex before this leaves prototype stage.
+// Where the mapping is uncertain, the code says so inline.
+//
+// Node-only: StdioJsonRpcClient spawns a child process.
+import { StdioJsonRpcClient } from "./stdio-jsonrpc";
+import type { AgentRuntime } from "./runtime";
+import type {
+  AgentInfo,
+  CommandInfo,
+  HistoryMessage,
+  OpenCodeEvent,
+  PermissionAskedEvent,
+  PermissionReply,
+  QuestionAskedEvent,
+  RuntimeStatus,
+  SessionMeta,
+  SkillInfo,
+} from "./types";
+
+/** Options to locate and start the codex app-server. */
+export interface CodexRuntimeOptions {
+  /**
+   * Command to spawn. Defaults to ["codex", "app-server"]. Override for a
+   * custom path or to wrap it (e.g. through npx).
+   */
+  command?: string[];
+  /** Extra env for the child (e.g. OPENAI_API_KEY). */
+  env?: Record<string, string>;
+  /** Working directory — should be the workspace the agent operates in. */
+  cwd?: string;
+}
+
+/**
+ * The pending approval a codex turn is blocked on, if any. The codex app-server
+ * pauses the turn and asks the client to approve a command before executing it.
+ */
+interface PendingApproval {
+  /** The id codex assigned to the approval request. */
+  id: string;
+  /** The shell command (or action) awaiting approval. */
+  command: string;
+}
+
+/**
+ * AgentRuntime implementation over the Codex App Server. Spawns
+ * `codex app-server` as a child process, drives it over JSON-RPC, and translates
+ * its events into the app's normalized `OpenCodeEvent` stream so the rest of the
+ * app (store, provenance, runs, UI) is unchanged.
+ */
+export class CodexRuntime implements AgentRuntime {
+  private rpc: StdioJsonRpcClient | null = null;
+  private status: RuntimeStatus = "offline";
+  /** threadId (codex) → accumulated text, so streamed deltas assemble like OpenCode. */
+  private readonly textStreams = new Map<string, string>();
+  /** threadId → the approval currently blocking it (one at a time per thread). */
+  private readonly pendingApprovals = new Map<string, PendingApproval>();
+  private readonly eventListeners = new Set<(e: OpenCodeEvent) => void>();
+  private readonly statusListeners = new Set<(s: RuntimeStatus) => void>();
+  private readonly unsubs: Array<() => void> = [];
+  private readonly options: CodexRuntimeOptions;
+
+  constructor(options: CodexRuntimeOptions = {}) {
+    this.options = options;
+  }
+
+  getStatus(): RuntimeStatus {
+    return this.status;
+  }
+
+  onEvent(listener: (e: OpenCodeEvent) => void): () => void {
+    this.eventListeners.add(listener);
+    return () => this.eventListeners.delete(listener);
+  }
+
+  onStatus(listener: (s: RuntimeStatus) => void): () => void {
+    this.statusListeners.add(listener);
+    return () => this.statusListeners.delete(listener);
+  }
+
+  /** Spawn codex app-server and run the JSON-RPC `initialize` handshake. */
+  async connect(): Promise<void> {
+    this.setStatus("connecting");
+    const rpc = new StdioJsonRpcClient({
+      command: this.options.command ?? ["codex", "app-server"],
+      env: this.options.env,
+      cwd: this.options.cwd,
+    });
+    // Surface codex stderr as a debug aid.
+    (rpc as unknown as { onStderr: (s: string) => void }).onStderr = (s: string) =>
+      void this.onStderr(s);
+    this.rpc = rpc;
+    this.registerHandlers(rpc);
+    try {
+      await rpc.start();
+      // Handshake: negotiate protocol. The exact field names are our best-effort
+      // reconstruction from public docs; confirm against a live codex.
+      await rpc.request("initialize", {
+        protocolVersion: "2025-03-26",
+        clientInfo: { name: "open-science-desktop", version: "0.2.0" },
+      });
+      this.setStatus("ready");
+    } catch (err) {
+      this.setStatus("error");
+      throw err;
+    }
+  }
+
+  close(): void {
+    this.unsubs.forEach((u) => u());
+    this.unsubs.length = 0;
+    void this.rpc?.close();
+    this.rpc = null;
+    this.textStreams.clear();
+    this.pendingApprovals.clear();
+    this.setStatus("offline");
+  }
+
+  // ---- sessions ----
+  // Codex app-server models a conversation as a "thread". createSession maps to
+  // starting a thread; the returned id is the codex thread id we use throughout.
+
+  async createSession(): Promise<string> {
+    this.requireReady();
+    const res = (await this.rpc!.request("thread/start", {
+      cwd: this.options.cwd,
+    })) as { id?: string } | string;
+    // Tolerate either a {id} object or a bare id string from the server.
+    const id = typeof res === "string" ? res : res?.id;
+    if (!id) throw new Error("codex thread/start returned no id");
+    return id;
+  }
+
+  async listSessions(): Promise<SessionMeta[]> {
+    // PROTOTYPE: codex app-server does not expose a thread-list RPC in the public
+    // surface we found. The app's history index (SQLite) is the source of truth
+    // for past sessions, so returning [] here is honest rather than guessing a
+    // method that may not exist. TODO: confirm against live codex.
+    return [];
+  }
+
+  async deleteSession(_sessionId: string): Promise<void> {
+    // PROTOTYPE: no known thread-delete RPC. No-op for now; the app keeps its own
+    // history index. TODO: confirm against live codex.
+  }
+
+  async getMessages(sessionId: string): Promise<HistoryMessage[]> {
+    this.requireReady();
+    // PROTOTYPE: we replay what we accumulated during the live stream. A history
+    // load across restarts needs the codex thread-load RPC, whose shape we have
+    // not confirmed. TODO: verify and replace.
+    const text = this.textStreams.get(sessionId);
+    if (!text) return [];
+    return [
+      {
+        role: "assistant",
+        parts: [{ type: "text", text }],
+      },
+    ];
+  }
+
+  /**
+   * Send a prompt into a codex thread. codex streams the turn back as
+   * notifications; this call awaits the terminal response (turn done).
+   * `agent?`/`model?` from AgentRuntime are accepted but not yet forwarded —
+   * codex thread config is set at thread/start; pinning per-turn needs the
+   * exact field names confirmed against live codex.
+   */
+  async sendPrompt(
+    sessionId: string,
+    text: string,
+    _agent?: string,
+    _model?: string | null,
+  ): Promise<void> {
+    this.requireReady();
+    // sendPrompt is a request whose RESULT means "turn complete"; the streaming
+    // text/tools arrive as notifications meanwhile. `fullOutput` asks codex to
+    // emit the complete final message in the response as a convenience.
+    await this.rpc!.request("thread/send", {
+      thread_id: sessionId,
+      prompt: text,
+      fullOutput: true,
+    });
+  }
+
+  async abortSession(sessionId: string): Promise<void> {
+    this.requireReady();
+    await this.rpc!.request("thread/cancel", { thread_id: sessionId }).catch(
+      () => undefined,
+    );
+  }
+
+  // ---- capability discovery ----
+  // These are OpenCode-shaped; codex has no skills/commands concept, so honest
+  // empties. `listAgents` could surface codex's built-in agent modes if/when the
+  // app-server exposes them.
+
+  async listSkills(): Promise<SkillInfo[]> {
+    return [];
+  }
+  async listAgents(): Promise<AgentInfo[]> {
+    return [];
+  }
+  async listCommands(): Promise<CommandInfo[]> {
+    return [];
+  }
+
+  // ---- model selection ----
+  // PROTOTYPE: codex picks its model from its own config / the thread's settings.
+  // The app's model picker is OpenCode-specific today; wiring it to codex needs
+  // the codex model-selection RPC, which we have not confirmed. These stubs keep
+  // the interface satisfied; TODO once the field names are verified.
+
+  async getDefaultModel(): Promise<string | null> {
+    return null;
+  }
+  async setDefaultModel(_model: string): Promise<void> {
+    // No-op in prototype: codex manages its own model selection.
+  }
+
+  // ---- agent-driven execution ----
+  // `runShell`/`runCommand` are OpenCode-native ("!" shell mode, slash commands).
+  // They have no codex equivalent. Throwing here would surface misleadingly in
+  // the UI; returning without action is safer for the prototype. TODO: decide
+  // whether to map these or disable the surface when codex is active.
+
+  async runShell(_sessionId: string, _command: string, _agent?: string): Promise<void> {
+    // No codex equivalent in the prototype.
+  }
+  async runCommand(
+    _sessionId: string,
+    _command: string,
+    _args?: string,
+  ): Promise<void> {
+    // No codex equivalent in the prototype.
+  }
+
+  // ---- interactive requests ----
+
+  async listQuestions(_sessionId?: string): Promise<QuestionAskedEvent[]> {
+    return [];
+  }
+
+  async listPermissions(_sessionId?: string): Promise<PermissionAskedEvent[]> {
+    // Surface any approvals that arrived before the listener connected.
+    const out: PermissionAskedEvent[] = [];
+    for (const [sid, a] of this.pendingApprovals) {
+      out.push({
+        type: "permission.asked",
+        sessionId: sid,
+        requestId: a.id,
+        action: "bash",
+        resources: [a.command],
+      });
+    }
+    return out;
+  }
+
+  async answerQuestion(_requestId: string, _answers: string[][]): Promise<void> {
+    // codex uses command-approval, not multi-option questions. No-op.
+  }
+  async rejectQuestion(_requestId: string): Promise<void> {
+    // codex uses command-approval, not multi-option questions. No-op.
+  }
+
+  /** Approve (or reject) a pending command approval. `always` persists a rule in
+   *  OpenCode; codex has no such notion, so it's treated as `once`. */
+  async replyPermission(requestId: string, reply: PermissionReply): Promise<void> {
+    this.requireReady();
+    const approved = reply !== "reject";
+    // Remove from pending regardless of outcome.
+    for (const [, a] of [...this.pendingApprovals])
+      if (a.id === requestId) this.pendingApprovals.delete(requestId);
+    // codex expects a decision on the approval id. Field name best-effort.
+    await this.rpc!
+      .request("approveCommand", { id: requestId, approved })
+      .catch(() => undefined);
+  }
+
+  // ---- internals ----
+
+  private requireReady(): void {
+    if (this.status !== "ready" || !this.rpc)
+      throw new Error("Codex runtime is not connected");
+  }
+
+  private registerHandlers(rpc: StdioJsonRpcClient): void {
+    // Streamed text: codex emits per-chunk notifications during a turn. We
+    // accumulate into textStreams and re-emit the full accumulated text, matching
+    // how OpenCodeClient feeds text.updated (full value, not delta).
+    this.unsubs.push(
+      rpc.onNotification("thread/message", (params) => {
+        const p = params as {
+          thread_id?: string;
+          delta?: string;
+          text?: string;
+          role?: string;
+        } | undefined;
+        const sid = p?.thread_id;
+        if (!sid || !p) return;
+        const chunk = p.delta ?? p.text ?? "";
+        if (!chunk) return;
+        const acc = (this.textStreams.get(sid) ?? "") + chunk;
+        this.textStreams.set(sid, acc);
+        this.emit({ type: "text.updated", sessionId: sid, partId: "text", text: acc });
+      }),
+    );
+
+    // Tool/command activity. codex reports a command executing and its result;
+    // we map both onto tool.updated with running→success. Field names best-effort.
+    this.unsubs.push(
+      rpc.onNotification("thread/command", (params) => {
+        const p = params as {
+          thread_id?: string;
+          id?: string;
+          command?: string;
+          state?: string;
+          output?: string;
+        } | undefined;
+        const sid = p?.thread_id;
+        if (!sid || !p?.id) return;
+        this.emit({
+          type: "tool.updated",
+          sessionId: sid,
+          callId: String(p.id),
+          tool: "bash",
+          status: p.state === "done" ? "success" : "running",
+          title: p.command ?? "command",
+          ...(typeof p.output === "string" ? { output: p.output } : {}),
+        });
+      }),
+    );
+
+    // Command approval request: codex pauses the turn and asks the client.
+    this.unsubs.push(
+      rpc.onNotification("thread/commandApprovalRequest", (params) => {
+        const p = params as {
+          thread_id?: string;
+          id?: string;
+          command?: string;
+        } | undefined;
+        const sid = p?.thread_id;
+        if (!sid || !p?.id) return;
+        const approval: PendingApproval = {
+          id: String(p.id),
+          command: p.command ?? "",
+        };
+        this.pendingApprovals.set(sid, approval);
+        this.emit({
+          type: "permission.asked",
+          sessionId: sid,
+          requestId: approval.id,
+          action: "bash",
+          resources: [approval.command],
+        });
+      }),
+    );
+
+    // Turn complete: codex ends the turn. We surface session.idle so the store
+    // unlocks the composer exactly like an OpenCode turn.
+    this.unsubs.push(
+      rpc.onNotification("thread/completed", (params) => {
+        const p = params as { thread_id?: string } | undefined;
+        const sid = p?.thread_id;
+        if (!sid) return;
+        this.emit({ type: "session.idle", sessionId: sid });
+      }),
+    );
+  }
+
+  private emit(event: OpenCodeEvent): void {
+    this.eventListeners.forEach((l) => l(event));
+  }
+
+  private setStatus(status: RuntimeStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    this.statusListeners.forEach((l) => l(status));
+  }
+
+  /** Override hook for stderr logging. */
+  protected onStderr(_chunk: string): void {}
+}

--- a/packages/sdk/src/CodexRuntime.ts
+++ b/packages/sdk/src/CodexRuntime.ts
@@ -264,9 +264,11 @@ export class CodexRuntime extends BaseAgentRuntime {
   async replyPermission(requestId: string, reply: PermissionReply): Promise<void> {
     this.requireReady();
     const approved = reply !== "reject";
-    // Remove from pending regardless of outcome.
-    for (const [, a] of [...this.pendingApprovals])
-      if (a.id === requestId) this.pendingApprovals.delete(requestId);
+    // pendingApprovals is keyed by thread id, so find the entry whose approval
+    // id matches requestId, then delete by THAT key (not requestId).
+    for (const [sid, a] of [...this.pendingApprovals]) {
+      if (a.id === requestId) this.pendingApprovals.delete(sid);
+    }
     // codex expects a decision on the approval id. Field name best-effort.
     await this.rpc!
       .request("approveCommand", { id: requestId, approved })

--- a/packages/sdk/src/OpenCodeClient.ts
+++ b/packages/sdk/src/OpenCodeClient.ts
@@ -6,7 +6,6 @@ import type {
   McpServer,
   OAuthAuthorization,
   OpenCodeClientOptions,
-  OpenCodeEvent,
   OpenCodePart,
   OpenCodeRawEvent,
   PermissionReply,
@@ -15,16 +14,13 @@ import type {
   ProviderInfo,
   QuestionAskedEvent,
   PermissionAskedEvent,
-  RuntimeStatus,
   SessionMeta,
   SkillInfo,
   ToolCallStatus,
 } from "./types";
 import { DEFAULT_OPENCODE_URL } from "./types";
 import type { AgentRuntime } from "./runtime";
-
-type EventListener = (event: OpenCodeEvent) => void;
-type StatusListener = (status: RuntimeStatus) => void;
+import { BaseAgentRuntime } from "./base-runtime";
 
 function mapToolStatus(status: string): ToolCallStatus {
   switch (status) {
@@ -63,7 +59,7 @@ function parseModel(model?: string | null): { providerID: string; modelID: strin
  * Talks to a running `opencode serve` over its HTTP + SSE API. The UI must go
  * through this class, never the transport directly (see AGENTS.md guardrails).
  */
-export class OpenCodeClient implements AgentRuntime {
+export class OpenCodeClient extends BaseAgentRuntime implements AgentRuntime {
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof fetch;
   private readonly authHeader: string | null;
@@ -77,7 +73,6 @@ export class OpenCodeClient implements AgentRuntime {
    *  calls (`/session/:id/…`) need no directory: the server routes them by the
    *  session's own recorded folder (verified live: `pwd` runs in it). */
   private readonly directory: string | null;
-  private status: RuntimeStatus = "offline";
   private abort: AbortController | null = null;
   private es: EventSource | null = null;
   /** Pending self-heal of a dead event stream (see reconnectSoon). */
@@ -87,8 +82,6 @@ export class OpenCodeClient implements AgentRuntime {
   private readonly customFetch: boolean;
   private readonly connectTimeoutMs: number;
   private readonly requestTimeoutMs: number;
-  private readonly eventListeners = new Set<EventListener>();
-  private readonly statusListeners = new Set<StatusListener>();
   /** messageID → role, learned from message.updated, to skip echoed user parts. */
   private readonly roles = new Map<string, string>();
   /** partID → accumulated text of a streaming text part. OpenCode publishes the
@@ -98,6 +91,7 @@ export class OpenCodeClient implements AgentRuntime {
   private readonly textStreams = new Map<string, { sessionId: string; text: string }>();
 
   constructor(opts: OpenCodeClientOptions = {}) {
+    super();
     this.baseUrl = (opts.baseUrl ?? DEFAULT_OPENCODE_URL).replace(/\/$/, "");
     this.customFetch = !!opts.fetchImpl;
     // Bind to globalThis — an unbound `fetch` reference throws "Illegal invocation" in browsers.
@@ -107,18 +101,6 @@ export class OpenCodeClient implements AgentRuntime {
     this.directory = opts.directory ?? null;
     this.connectTimeoutMs = opts.connectTimeoutMs ?? 5000;
     this.requestTimeoutMs = opts.requestTimeoutMs ?? 15000;
-  }
-
-  getStatus(): RuntimeStatus {
-    return this.status;
-  }
-  onEvent(l: EventListener): () => void {
-    this.eventListeners.add(l);
-    return () => this.eventListeners.delete(l);
-  }
-  onStatus(l: StatusListener): () => void {
-    this.statusListeners.add(l);
-    return () => this.statusListeners.delete(l);
   }
 
   private headers(json = false): Record<string, string> {
@@ -1024,14 +1006,5 @@ export class OpenCodeClient implements AgentRuntime {
       default:
         break; // server.connected and others are ignored
     }
-  }
-
-  private emit(event: OpenCodeEvent): void {
-    this.eventListeners.forEach((l) => l(event));
-  }
-  private setStatus(status: RuntimeStatus): void {
-    if (this.status === status) return;
-    this.status = status;
-    this.statusListeners.forEach((l) => l(status));
   }
 }

--- a/packages/sdk/src/base-runtime.ts
+++ b/packages/sdk/src/base-runtime.ts
@@ -1,0 +1,57 @@
+// BaseAgentRuntime: shared infrastructure for every AgentRuntime implementation.
+//
+// The listener/status machinery (getStatus / onEvent / onStatus / emit /
+// setStatus) is identical across runtimes — OpenCodeClient and CodexRuntime
+// had byte-for-byte copies. This base class factors it out so a new runtime
+// author fills in ONLY their protocol-specific methods (connect, createSession,
+// sendPrompt, ...) and inherits the plumbing.
+//
+// To add a new agent runtime, extend this class and implement the remaining
+// AgentRuntime methods. See docs/AGENT_INTEGRATION.md for a step-by-step guide.
+import type { OpenCodeEvent, RuntimeStatus } from "./types";
+
+/**
+ * Listener + status plumbing shared by every runtime. A subclass extends this
+ * and implements its protocol-specific AgentRuntime methods (connect,
+ * createSession, sendPrompt, …), calling `setStatus()` as it transitions and
+ * `emit()` to fan out normalized events.
+ *
+ * `getStatus` / `onEvent` / `onStatus` are final here — they never differ by
+ * runtime, so they are intentionally NOT overridable in practice.
+ */
+export abstract class BaseAgentRuntime {
+  private status: RuntimeStatus = "offline";
+  private readonly eventListeners = new Set<(e: OpenCodeEvent) => void>();
+  private readonly statusListeners = new Set<(s: RuntimeStatus) => void>();
+
+  /** Current runtime status. Implements `AgentRuntime.getStatus`. */
+  getStatus(): RuntimeStatus {
+    return this.status;
+  }
+
+  /** Subscribe to normalized runtime events. Returns an unsubscribe. */
+  onEvent(listener: (event: OpenCodeEvent) => void): () => void {
+    this.eventListeners.add(listener);
+    return () => this.eventListeners.delete(listener);
+  }
+
+  /** Subscribe to status transitions. Returns an unsubscribe. */
+  onStatus(listener: (status: RuntimeStatus) => void): () => void {
+    this.statusListeners.add(listener);
+    return () => this.statusListeners.delete(listener);
+  }
+
+  // ---- tools for subclasses ----
+
+  /** Fan a normalized event out to every onEvent listener. */
+  protected emit(event: OpenCodeEvent): void {
+    this.eventListeners.forEach((l) => l(event));
+  }
+
+  /** Transition status and notify onStatus listeners. A no-op if unchanged. */
+  protected setStatus(status: RuntimeStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    this.statusListeners.forEach((l) => l(status));
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,7 @@
 export { OpenCodeClient } from "./OpenCodeClient";
 export type { AgentRuntime } from "./runtime";
+export { CodexRuntime, type CodexRuntimeOptions } from "./CodexRuntime";
+export { StdioJsonRpcClient, type StdioJsonRpcOptions } from "./stdio-jsonrpc";
 export {
   OPENCODE_VERSION,
   DEFAULT_OPENCODE_URL,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,8 +1,9 @@
 export { OpenCodeClient } from "./OpenCodeClient";
 export type { AgentRuntime } from "./runtime";
 export { BaseAgentRuntime } from "./base-runtime";
-export { CodexRuntime, type CodexRuntimeOptions } from "./CodexRuntime";
-export { StdioJsonRpcClient, type StdioJsonRpcOptions } from "./stdio-jsonrpc";
+// CodexRuntime / StdioJsonRpcClient live in the "./node-runtime" subpath — they
+// spawn child processes (node:child_process) and must never enter the browser
+// barrel. Import them from "@ai4s/sdk/node-runtime".
 export {
   OPENCODE_VERSION,
   DEFAULT_OPENCODE_URL,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,6 @@
 export { OpenCodeClient } from "./OpenCodeClient";
 export type { AgentRuntime } from "./runtime";
+export { BaseAgentRuntime } from "./base-runtime";
 export { CodexRuntime, type CodexRuntimeOptions } from "./CodexRuntime";
 export { StdioJsonRpcClient, type StdioJsonRpcOptions } from "./stdio-jsonrpc";
 export {

--- a/packages/sdk/src/node-runtime.ts
+++ b/packages/sdk/src/node-runtime.ts
@@ -1,0 +1,7 @@
+// Node-only entry point for agent runtimes that spawn child processes.
+// Re-exported via the "./node-runtime" subpath so the bundler never pulls
+// node:child_process into the browser barrel (index.ts). Mirror of how
+// mock-server.ts is exposed.
+export { CodexRuntime, type CodexRuntimeOptions } from "./CodexRuntime";
+export { StdioJsonRpcClient, type StdioJsonRpcOptions } from "./stdio-jsonrpc";
+export { BaseAgentRuntime } from "./base-runtime";

--- a/packages/sdk/src/stdio-jsonrpc.ts
+++ b/packages/sdk/src/stdio-jsonrpc.ts
@@ -1,0 +1,231 @@
+// A minimal JSON-RPC 2.0 client over a child process's stdio. Shared transport
+// for any runtime that speaks line-delimited JSON-RPC to a spawned binary —
+// today CodexRuntime (codex app-server); tomorrow AcpRuntime (any ACP agent).
+// See docs/rfc/multi-agent-acp.md: this is the layer both consume.
+//
+// Node-only: it spawns a real child process. Browser builds never import it.
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+/** A JSON-RPC 2.0 request (expects a response). */
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number | string;
+  method: string;
+  params?: unknown;
+}
+/** A JSON-RPC 2.0 notification (no response expected). */
+interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+/** A JSON-RPC 2.0 response to a prior request. */
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number | string;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface StdioJsonRpcOptions {
+  /** Command to spawn, e.g. ["codex", "app-server"]. */
+  command: string[];
+  /** Extra env for the child (merged over process.env). */
+  env?: Record<string, string>;
+  /** Working directory for the child. */
+  cwd?: string;
+  /** Ms to wait for the child to exit on close() before SIGKILL. Default 3000. */
+  killGraceMs?: number;
+}
+
+/**
+ * Speaks line-delimited JSON-RPC 2.0 to a spawned child process over its
+ * stdin/stdout. Each JSON object is one line (newline-delimited).
+ *
+ * - `request(method, params)` → awaits the matching response by id.
+ * - `onNotification(method, handler)` → fires for server-initiated messages.
+ * - `notify(method, params)` → sends a notification (no response).
+ */
+export class StdioJsonRpcClient {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private nextId = 0;
+  private readonly pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private readonly notificationHandlers = new Map<
+    string,
+    Set<(params: unknown) => void>
+  >();
+  private buffer = "";
+  private readonly options: StdioJsonRpcOptions;
+
+  constructor(options: StdioJsonRpcOptions) {
+    this.options = options;
+  }
+
+  /** Spawn the child. Resolves once stdout is open; the caller then does the
+   *  protocol handshake (e.g. `initialize`). */
+  start(): Promise<void> {
+    if (this.proc) throw new Error("StdioJsonRpcClient already started");
+    const [cmd, ...args] = this.options.command;
+    return new Promise((resolve, reject) => {
+      const proc = spawn(cmd, args, {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, ...this.options.env },
+        cwd: this.options.cwd,
+      });
+      this.proc = proc;
+      let opened = false;
+      const fail = (err: Error) => {
+        if (!opened) {
+          opened = true;
+          reject(err);
+        } else {
+          this.onError(err);
+        }
+      };
+      proc.on("error", fail);
+      proc.on("exit", (code, signal) => {
+        // Reject any in-flight requests: the answers will never come.
+        const msg = `child exited (code ${code}, signal ${signal})`;
+        for (const p of this.pending.values()) p.reject(new Error(msg));
+        this.pending.clear();
+        if (!opened) fail(new Error(msg));
+        else this.onExit(code, signal);
+      });
+      proc.stdout.setEncoding("utf8");
+      proc.stdout.on("data", (chunk: string) => {
+        if (!opened) {
+          opened = true;
+          resolve();
+        }
+        this.onStdout(chunk);
+      });
+      proc.stderr.setEncoding("utf8");
+      proc.stderr.on("data", (chunk: string) => this.onStderr(chunk));
+    });
+  }
+
+  /** Send a request and await the matching response. */
+  request(method: string, params?: unknown): Promise<unknown> {
+    if (!this.proc || !this.proc.stdin.writable) {
+      return Promise.reject(new Error("JSON-RPC child is not running"));
+    }
+    const id = this.nextId++;
+    const msg: JsonRpcRequest = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.write(msg);
+    });
+  }
+
+  /** Send a notification (no response expected). */
+  notify(method: string, params?: unknown): void {
+    const msg: JsonRpcNotification = { jsonrpc: "2.0", method, params };
+    this.write(msg);
+  }
+
+  /** Listen for a server-initiated notification/method. Returns an unsubscribe. */
+  onNotification(method: string, handler: (params: unknown) => void): () => void {
+    let set = this.notificationHandlers.get(method);
+    if (!set) {
+      set = new Set();
+      this.notificationHandlers.set(method, set);
+    }
+    set.add(handler);
+    return () => set!.delete(handler);
+  }
+
+  /** Stop the child: close stdin, then SIGTERM → SIGKILL after the grace. */
+  async close(): Promise<void> {
+    const proc = this.proc;
+    if (!proc) return;
+    this.proc = null;
+    try {
+      proc.stdin.end();
+    } catch {
+      /* already closed */
+    }
+    await new Promise<void>((resolve) => {
+      const grace = this.options.killGraceMs ?? 3000;
+      const timer = setTimeout(() => {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          /* already dead */
+        }
+        resolve();
+      }, grace);
+      proc.on("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  // ---- hooks a subclass (or caller) can override ----
+
+  /** Called on stderr output. Default: ignore. Override to log diagnostics. */
+  protected onStderr(_chunk: string): void {}
+  /** Called when the child exits unexpectedly after start. Default: no-op. */
+  protected onExit(_code: number | null, _signal: NodeJS.Signals | null): void {}
+  /** Called on a transport-level error. Default: no-op. */
+  protected onError(_err: Error): void {}
+
+  // ---- internals ----
+
+  private write(msg: JsonRpcRequest | JsonRpcNotification): void {
+    const proc = this.proc;
+    if (!proc) return;
+    proc.stdin.write(JSON.stringify(msg) + "\n");
+  }
+
+  private onStdout(chunk: string): void {
+    this.buffer += chunk;
+    let nl: number;
+    while ((nl = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, nl).trim();
+      this.buffer = this.buffer.slice(nl + 1);
+      if (!line) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue; // skip malformed lines
+      }
+      this.handleMessage(parsed as JsonRpcResponse | JsonRpcNotification);
+    }
+  }
+
+  private handleMessage(msg: JsonRpcResponse | JsonRpcNotification): void {
+    // A response carries an id matching a pending request.
+    if (
+      typeof msg === "object" &&
+      msg !== null &&
+      "id" in msg &&
+      (msg.id === 0 || !!msg.id) &&
+      ("result" in msg || "error" in msg) &&
+      !("method" in msg)
+    ) {
+      const id = typeof msg.id === "string" ? Number(msg.id) : msg.id;
+      const pending = this.pending.get(id);
+      if (pending) {
+        this.pending.delete(id);
+        if (msg.error) {
+          pending.reject(
+            new Error(`${msg.error.message} (code ${msg.error.code})`),
+          );
+        } else {
+          pending.resolve(msg.result);
+        }
+      }
+      return;
+    }
+    // Otherwise it's a notification (has `method`, no id).
+    if (typeof msg === "object" && msg !== null && "method" in msg) {
+      const handlers = this.notificationHandlers.get(msg.method);
+      if (handlers) handlers.forEach((h) => h((msg as JsonRpcNotification).params));
+    }
+  }
+}


### PR DESCRIPTION
> ⚠️ **Prototype / experiment.** CodexRuntime validated the `AgentRuntime`
> interface (#24, merged) against a real second runtime and lands the shared
> stdio JSON-RPC transport for the ACP roadmap (#25, merged). Not wired into
> the running app — awaits verification against a real `codex app-server`.

## Review fixes applied (thanks @noahbenjamin1994)

- ✅ **Split the base-class refactor out** → #36 (behavior-preserving, can land
  immediately). This PR keeps only the CodexRuntime prototype.
- ✅ **Fixed the `replyPermission` bug**: `pendingApprovals` is keyed by thread
  id but was deleted by `requestId`, so approvals never cleared. Now deletes by
  the matching key, with a regression test asserting `listPermissions` is empty
  after a reply.
- ✅ **Moved node-only code out of the browser barrel**:
  `CodexRuntime` / `StdioJsonRpcClient` now live in a `@ai4s/sdk/node-runtime`
  subpath (mirroring `mock-server`), plus the matching vite alias. `index.ts`
  keeps only `BaseAgentRuntime` (no `child_process` dependency).

## What this PR now contains (after the split)

| File | Purpose |
| --- | --- |
| `packages/sdk/src/stdio-jsonrpc.ts` 🆕 | `StdioJsonRpcClient`: JSON-RPC framing + request/notification + child lifecycle |
| `packages/sdk/src/node-runtime.ts` 🆕 | node-only entry: exports CodexRuntime + StdioJsonRpcClient (no browser barrel) |
| `packages/sdk/src/CodexRuntime.ts` 🆕 | `CodexRuntime extends BaseAgentRuntime`: codex protocol → `OpenCodeEvent` |
| `packages/sdk/package.json` | add `"./node-runtime"` subpath |
| `apps/desktop/vite.config.ts` | `@ai4s/sdk/node-runtime` alias (mirrors `mock-server`) |
| `docs/AGENT_INTEGRATION.md` 🆕 | how-to guide for contributing a new agent runtime |
| `apps/desktop/src/test/stdio-jsonrpc.test.ts` 🆕 | transport (7 tests) |
| `apps/desktop/src/test/codex-runtime.test.ts` 🆕 | protocol translation (3 tests, incl. the replyPermission regression) |

`BaseAgentRuntime` and the `OpenCodeClient` refactor are in **#36**, not here.

## Status

This prototype **holds** per review until verified against a real
`codex app-server`. The structural work (base class #36) is now unblocked and
can land independently.

## ⚠️ Still needs real-world confirmation

The codex app-server JSON-RPC protocol is **reconstructed from public docs**,
not verified against a live binary. Method/field names are best-effort; if the
real protocol differs, both CodexRuntime and its mock change together (the
tests catch the drift). Not run against a real `codex` CLI yet — that needs a
machine with `codex` + an OpenAI key.

## Verification

- ✅ `pnpm typecheck` — clean for all changed files
- ✅ `pnpm lint` — clean
- ✅ 28/28 tests passing (OpenCodeClient 18 + transport 7 + CodexRuntime 3)

cc — advances #14, validated #24, de-risks #25. Base-class half now in #36.