### PR TITLE
fix(ui): scroll long clarifying-question lists instead of clipping them

### DIFF
--- a/apps/desktop/src/components/thread/InteractionPrompt.tsx
+++ b/apps/desktop/src/components/thread/InteractionPrompt.tsx
@@ -106,7 +106,7 @@ function QuestionCard({
         )}
       </header>
 
-      <div className="space-y-4 px-4 py-3.5">
+      <div className="max-h-[45vh] space-y-4 overflow-y-auto px-4 py-3.5">
         {items.map((it, qi) => {
           const multiple = !!it.multiple;
           return (


### PR DESCRIPTION
## Problem

`InteractionPrompt` has no scroll region of its own. When the agent asks more questions than fit on one screen, the overflow is clipped with no way to reach the remaining questions or the Submit button.

## Fix

```diff
-      <div className="space-y-4 px-4 py-3.5">
+      <div className="max-h-[45vh] space-y-4 overflow-y-auto px-4 py-3.5">
```

Scrolls the question list internally; header and Skip/Submit footer stay outside it, always reachable. Same pattern as ModelBrowser/CommandPalette.

## Verification

✅ pnpm typecheck
✅ pnpm lint
✅ cargo test 96/96 (no Rust changes)
⚠️ pnpm test has a pre-existing, unrelated failure (window.localStorage in src/test/setup.ts) — confirmed identical with/without this change.

## Possible follow-up
An auto-advancing multi-step form (one question at a time, wizard-style) could avoid scrolling entirely and might be a nicer UX overall.
