### PR TITLE
refactor(sdk): extract BaseAgentRuntime base class

### DIFF
--- a/packages/sdk/src/OpenCodeClient.ts
+++ b/packages/sdk/src/OpenCodeClient.ts
@@ -6,7 +6,6 @@ import type {
   McpServer,
   OAuthAuthorization,
   OpenCodeClientOptions,
-  OpenCodeEvent,
   OpenCodePart,
   OpenCodeRawEvent,
   PermissionReply,
@@ -15,16 +14,13 @@ import type {
   ProviderInfo,
   QuestionAskedEvent,
   PermissionAskedEvent,
-  RuntimeStatus,
   SessionMeta,
   SkillInfo,
   ToolCallStatus,
 } from "./types";
 import { DEFAULT_OPENCODE_URL } from "./types";
 import type { AgentRuntime } from "./runtime";
-
-type EventListener = (event: OpenCodeEvent) => void;
-type StatusListener = (status: RuntimeStatus) => void;
+import { BaseAgentRuntime } from "./base-runtime";
 
 function mapToolStatus(status: string): ToolCallStatus {
   switch (status) {
@@ -63,7 +59,7 @@ function parseModel(model?: string | null): { providerID: string; modelID: strin
  * Talks to a running `opencode serve` over its HTTP + SSE API. The UI must go
  * through this class, never the transport directly (see AGENTS.md guardrails).
  */
-export class OpenCodeClient implements AgentRuntime {
+export class OpenCodeClient extends BaseAgentRuntime implements AgentRuntime {
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof fetch;
   private readonly authHeader: string | null;
@@ -77,7 +73,6 @@ export class OpenCodeClient implements AgentRuntime {
    *  calls (`/session/:id/…`) need no directory: the server routes them by the
    *  session's own recorded folder (verified live: `pwd` runs in it). */
   private readonly directory: string | null;
-  private status: RuntimeStatus = "offline";
   private abort: AbortController | null = null;
   private es: EventSource | null = null;
   /** Pending self-heal of a dead event stream (see reconnectSoon). */
@@ -87,8 +82,6 @@ export class OpenCodeClient implements AgentRuntime {
   private readonly customFetch: boolean;
   private readonly connectTimeoutMs: number;
   private readonly requestTimeoutMs: number;
-  private readonly eventListeners = new Set<EventListener>();
-  private readonly statusListeners = new Set<StatusListener>();
   /** messageID → role, learned from message.updated, to skip echoed user parts. */
   private readonly roles = new Map<string, string>();
   /** partID → accumulated text of a streaming text part. OpenCode publishes the
@@ -98,6 +91,7 @@ export class OpenCodeClient implements AgentRuntime {
   private readonly textStreams = new Map<string, { sessionId: string; text: string }>();
 
   constructor(opts: OpenCodeClientOptions = {}) {
+    super();
     this.baseUrl = (opts.baseUrl ?? DEFAULT_OPENCODE_URL).replace(/\/$/, "");
     this.customFetch = !!opts.fetchImpl;
     // Bind to globalThis — an unbound `fetch` reference throws "Illegal invocation" in browsers.
@@ -107,18 +101,6 @@ export class OpenCodeClient implements AgentRuntime {
     this.directory = opts.directory ?? null;
     this.connectTimeoutMs = opts.connectTimeoutMs ?? 5000;
     this.requestTimeoutMs = opts.requestTimeoutMs ?? 15000;
-  }
-
-  getStatus(): RuntimeStatus {
-    return this.status;
-  }
-  onEvent(l: EventListener): () => void {
-    this.eventListeners.add(l);
-    return () => this.eventListeners.delete(l);
-  }
-  onStatus(l: StatusListener): () => void {
-    this.statusListeners.add(l);
-    return () => this.statusListeners.delete(l);
   }
 
   private headers(json = false): Record<string, string> {
@@ -1024,14 +1006,5 @@ export class OpenCodeClient implements AgentRuntime {
       default:
         break; // server.connected and others are ignored
     }
-  }
-
-  private emit(event: OpenCodeEvent): void {
-    this.eventListeners.forEach((l) => l(event));
-  }
-  private setStatus(status: RuntimeStatus): void {
-    if (this.status === status) return;
-    this.status = status;
-    this.statusListeners.forEach((l) => l(status));
   }
 }

--- a/packages/sdk/src/base-runtime.ts
+++ b/packages/sdk/src/base-runtime.ts
@@ -1,0 +1,57 @@
+// BaseAgentRuntime: shared infrastructure for every AgentRuntime implementation.
+//
+// The listener/status machinery (getStatus / onEvent / onStatus / emit /
+// setStatus) is identical across runtimes — OpenCodeClient and CodexRuntime
+// had byte-for-byte copies. This base class factors it out so a new runtime
+// author fills in ONLY their protocol-specific methods (connect, createSession,
+// sendPrompt, ...) and inherits the plumbing.
+//
+// To add a new agent runtime, extend this class and implement the remaining
+// AgentRuntime methods. See docs/AGENT_INTEGRATION.md for a step-by-step guide.
+import type { OpenCodeEvent, RuntimeStatus } from "./types";
+
+/**
+ * Listener + status plumbing shared by every runtime. A subclass extends this
+ * and implements its protocol-specific AgentRuntime methods (connect,
+ * createSession, sendPrompt, …), calling `setStatus()` as it transitions and
+ * `emit()` to fan out normalized events.
+ *
+ * `getStatus` / `onEvent` / `onStatus` are final here — they never differ by
+ * runtime, so they are intentionally NOT overridable in practice.
+ */
+export abstract class BaseAgentRuntime {
+  private status: RuntimeStatus = "offline";
+  private readonly eventListeners = new Set<(e: OpenCodeEvent) => void>();
+  private readonly statusListeners = new Set<(s: RuntimeStatus) => void>();
+
+  /** Current runtime status. Implements `AgentRuntime.getStatus`. */
+  getStatus(): RuntimeStatus {
+    return this.status;
+  }
+
+  /** Subscribe to normalized runtime events. Returns an unsubscribe. */
+  onEvent(listener: (event: OpenCodeEvent) => void): () => void {
+    this.eventListeners.add(listener);
+    return () => this.eventListeners.delete(listener);
+  }
+
+  /** Subscribe to status transitions. Returns an unsubscribe. */
+  onStatus(listener: (status: RuntimeStatus) => void): () => void {
+    this.statusListeners.add(listener);
+    return () => this.statusListeners.delete(listener);
+  }
+
+  // ---- tools for subclasses ----
+
+  /** Fan a normalized event out to every onEvent listener. */
+  protected emit(event: OpenCodeEvent): void {
+    this.eventListeners.forEach((l) => l(event));
+  }
+
+  /** Transition status and notify onStatus listeners. A no-op if unchanged. */
+  protected setStatus(status: RuntimeStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    this.statusListeners.forEach((l) => l(status));
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,6 @@
 export { OpenCodeClient } from "./OpenCodeClient";
 export type { AgentRuntime } from "./runtime";
+export { BaseAgentRuntime } from "./base-runtime";
 export {
   OPENCODE_VERSION,
   DEFAULT_OPENCODE_URL,


### PR DESCRIPTION
Split out from #28 per review. This is the **behavior-preserving cleanup** half
that can land right away; the CodexRuntime prototype stays in #28 until it's
verified against a real `codex app-server`.

## What this does

Extracts the listener/status machinery that every `AgentRuntime` needs into an
abstract **`BaseAgentRuntime`**, so a new runtime fills in only its protocol
translation instead of copy-pasting plumbing. `OpenCodeClient` is refactored to
extend it.

```ts
// packages/sdk/src/base-runtime.ts (new)
export abstract class BaseAgentRuntime {
  getStatus(): RuntimeStatus                      // inherited
  onEvent(listener): () => void                   // inherited
  onStatus(listener): () => void                  // inherited
  protected emit(event: OpenCodeEvent): void      // tool for subclasses
  protected setStatus(status: RuntimeStatus): void
}

// OpenCodeClient — drops its private copies, extends the base
export class OpenCodeClient extends BaseAgentRuntime implements AgentRuntime { … }
```

## Why split it out

Per @noahbenjamin1994 on #28: the base-class extraction is clean and
behavior-preserving, so it can land independently; the CodexRuntime itself waits
on real-binary verification. This PR contains **only** the refactor — no
CodexRuntime, no stdio transport, no new tests, no docs.

## Verification

- ✅ `pnpm typecheck` — clean
- ✅ `pnpm lint` — clean
- ✅ `opencode-client.node.test.ts` **18/18 passing** — proves the refactor is
  behavior-preserving for the production runtime
- Net **−29 lines** in `OpenCodeClient` (the duplicated fields/methods move to the base)

## Files

| File | Change |
| --- | --- |
| `packages/sdk/src/base-runtime.ts` 🆕 | abstract `BaseAgentRuntime` |
| `packages/sdk/src/OpenCodeClient.ts` | `extends BaseAgentRuntime`, drop private duplicates, `super()` |
| `packages/sdk/src/index.ts` | export `BaseAgentRuntime` |

Once this lands, #28 rebases onto it and the `CodexRuntime extends BaseAgentRuntime` line becomes a one-liner.