### PR TITLE
feat: Codex-style model + effort selector in Composer

### DIFF
--- a/apps/desktop/src/app/routes/SettingsPage.modelBrowser.test.tsx
+++ b/apps/desktop/src/app/routes/SettingsPage.modelBrowser.test.tsx
@@ -17,8 +17,8 @@ const providers: ProviderInfo[] = [
     id: "openai",
     name: "OpenAI",
     models: [
-      { id: "gpt-5.2", name: "GPT-5.2" },
-      { id: "o3", name: "o3" },
+      { id: "gpt-5.2", name: "GPT-5.2", variants: [] },
+      { id: "o3", name: "o3", variants: [] },
     ],
   },
 ];

--- a/apps/desktop/src/components/settings/ModelBrowser.test.tsx
+++ b/apps/desktop/src/components/settings/ModelBrowser.test.tsx
@@ -7,11 +7,11 @@ import { ModelBrowser } from "./ModelBrowser";
 
 const providers: ProviderInfo[] = [
   { id: "openai", name: "OpenAI", models: [
-    { id: "gpt-5.2", name: "GPT-5.2" },
-    { id: "o3", name: "o3" },
+    { id: "gpt-5.2", name: "GPT-5.2", variants: [] },
+    { id: "o3", name: "o3", variants: [] },
   ] },
   { id: "ollama", name: "Ollama Cloud", models: [
-    { id: "qwen3-coder", name: "Qwen3 Coder" },
+    { id: "qwen3-coder", name: "Qwen3 Coder", variants: [] },
   ] },
 ];
 

--- a/apps/desktop/src/components/settings/modelCatalog.test.ts
+++ b/apps/desktop/src/components/settings/modelCatalog.test.ts
@@ -12,14 +12,14 @@ const providers: ProviderInfo[] = [
     id: "openai",
     name: "OpenAI",
     models: [
-      { id: "gpt-5.2", name: "GPT-5.2" },
-      { id: "o3", name: "o3" },
+      { id: "gpt-5.2", name: "GPT-5.2", variants: [] },
+      { id: "o3", name: "o3", variants: [] },
     ],
   },
   {
     id: "ollama-cloud",
     name: "Ollama Cloud",
-    models: [{ id: "qwen3-coder", name: "Qwen3 Coder" }],
+    models: [{ id: "qwen3-coder", name: "Qwen3 Coder", variants: [] }],
   },
 ];
 

--- a/apps/desktop/src/components/settings/modelCatalog.ts
+++ b/apps/desktop/src/components/settings/modelCatalog.ts
@@ -6,6 +6,7 @@ export interface ModelOption {
   providerName: string;
   modelID: string;
   modelName: string;
+  variants: string[];
 }
 
 export type ModelFilter =
@@ -22,6 +23,7 @@ export function flattenModelOptions(providers: ProviderInfo[]): ModelOption[] {
       providerName: provider.name,
       modelID: model.id,
       modelName: model.name,
+      variants: model.variants ?? [],
     })),
   );
 }

--- a/apps/desktop/src/components/sidebar/StatusPills.tsx
+++ b/apps/desktop/src/components/sidebar/StatusPills.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import type { ModelStatus, RuntimeStatus } from "@ai4s/shared";
+import type { RuntimeStatus } from "@ai4s/shared";
 import { useRuntimeStore } from "@/lib/runtime";
 import { cn } from "@/lib/cn";
 
@@ -10,18 +10,9 @@ const RUNTIME_TONE: Record<RuntimeStatus, string> = {
   offline: "bg-muted",
 };
 
-const MODEL_TONE: Record<ModelStatus, string> = {
-  connected: "bg-ok",
-  disconnected: "bg-muted",
-  error: "bg-error",
-};
-
 export function StatusPills() {
   const { t } = useTranslation("nav");
-  // Both live from the runtime: connection status + the configured default model.
   const runtime = useRuntimeStore((s) => s.status);
-  const defaultModel = useRuntimeStore((s) => s.defaultModel);
-  const model: ModelStatus = defaultModel ? "connected" : "disconnected";
 
   return (
     <div className="flex flex-col gap-1 text-xs text-muted">
@@ -29,11 +20,6 @@ export function StatusPills() {
         dot={RUNTIME_TONE[runtime]}
         label={t("status.runtime")}
         value={t(`status.values.${runtime}`)}
-      />
-      <Pill
-        dot={MODEL_TONE[model]}
-        label={t("status.model")}
-        value={defaultModel ? defaultModel.split("/").pop()! : t("status.modelNotSet")}
       />
     </div>
   );

--- a/apps/desktop/src/components/thread/Composer.tsx
+++ b/apps/desktop/src/components/thread/Composer.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/tauri";
 import { useRuntimeStore, type AgentMode } from "@/lib/runtime";
 import { WorkspaceChip } from "@/components/thread/WorkspaceChip";
+import { ModelEffortSelector } from "@/components/thread/ModelEffortSelector";
 import { useUiStore } from "@/lib/store";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/cn";
@@ -730,6 +731,7 @@ export function Composer({
             </button>
           </div>
         )}
+        <ModelEffortSelector />
         <span className="flex-1" />
         {working && onStop ? (
           // Same spot, same shape, one action: the send button becomes Stop

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { ChevronDown, Cpu } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { useRuntimeStore } from "@/lib/runtime";
 import { flattenModelOptions } from "@/components/settings/modelCatalog";
@@ -7,6 +8,7 @@ import { resolveSelection, selectionAvailability } from "@/lib/modelSelection";
 import type { ModelSelection } from "@/lib/modelSelection";
 
 export function ModelEffortSelector() {
+  const { t } = useTranslation("session");
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const providers = useRuntimeStore((s) => s.providers);
@@ -29,12 +31,12 @@ export function ModelEffortSelector() {
   if (options.length === 0) return null;
 
   const modelLabel = currentOption
-    ? `${currentOption.modelName}${currentOption.providerName ? ` \u00b7 ${currentOption.providerName}` : ""}`
-    : "Not set";
+    ? `${currentOption.modelName}${currentOption.providerName ? ` · ${currentOption.providerName}` : ""}`
+    : t("composer.modelSelector.notSet");
 
   const variantLabel = selection?.variant
     ? selection.variant
-    : "Default";
+    : t("composer.modelSelector.defaultVariant");
 
   const handlePickModel = async (modelKey: string) => {
     const newSelection: ModelSelection = { model: modelKey, variant: null };
@@ -57,10 +59,12 @@ export function ModelEffortSelector() {
       {open && (
         <div
           role="menu"
-          aria-label="Model selector"
+          aria-label={t("composer.modelSelector.menuAria")}
           className="absolute bottom-full left-0 z-20 mb-2 w-80 rounded-card border border-border bg-surface p-1 shadow-card"
         >
-          <div className="px-2 pb-1 pt-1.5 text-xs text-muted">Model</div>
+          <div className="px-2 pb-1 pt-1.5 text-xs text-muted">
+            {t("composer.modelSelector.modelSection")}
+          </div>
           <div className="max-h-48 overflow-y-auto">
             {options.map((opt) => (
               <button
@@ -76,17 +80,19 @@ export function ModelEffortSelector() {
                 <Cpu size={13} className="shrink-0 text-muted" />
                 <span className="min-w-0 flex-1 truncate text-xs text-text">
                   {opt.modelName}
-                  <span className="text-muted"> \u00b7 {opt.providerName}</span>
+                  <span className="text-muted"> · {opt.providerName}</span>
                 </span>
                 {opt.key === currentModelKey && (
-                  <span className="shrink-0 text-xs text-accent">\u2713</span>
+                  <span className="shrink-0 text-xs text-accent">✓</span>
                 )}
               </button>
             ))}
           </div>
           {variants.length > 0 && (
             <>
-              <div className="mt-1 border-t border-border px-2 pb-1 pt-1.5 text-xs text-muted">Reasoning</div>
+              <div className="mt-1 border-t border-border px-2 pb-1 pt-1.5 text-xs text-muted">
+                {t("composer.modelSelector.variantSection")}
+              </div>
               <button
                 role="menuitemradio"
                 aria-checked={!selection?.variant}
@@ -96,8 +102,10 @@ export function ModelEffortSelector() {
                   handlePickVariant(null);
                 }}
               >
-                <span className="min-w-0 flex-1 truncate text-xs text-text">Default</span>
-                {!selection?.variant && <span className="shrink-0 text-xs text-accent">\u2713</span>}
+                <span className="min-w-0 flex-1 truncate text-xs text-text">
+                  {t("composer.modelSelector.defaultVariant")}
+                </span>
+                {!selection?.variant && <span className="shrink-0 text-xs text-accent">✓</span>}
               </button>
               {variants.map((v) => (
                 <button
@@ -111,7 +119,7 @@ export function ModelEffortSelector() {
                   }}
                 >
                   <span className="min-w-0 flex-1 truncate text-xs text-text">{v}</span>
-                  {selection?.variant === v && <span className="shrink-0 text-xs text-accent">\u2713</span>}
+                  {selection?.variant === v && <span className="shrink-0 text-xs text-accent">✓</span>}
                 </button>
               ))}
             </>
@@ -119,8 +127,8 @@ export function ModelEffortSelector() {
         </div>
       )}
       <button
-        aria-label="Model selector"
-        title="Model and reasoning level"
+        aria-label={t("composer.modelSelector.aria")}
+        title={t("composer.modelSelector.title")}
         className={cn(
           "flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs",
           availability !== "available"
@@ -132,7 +140,7 @@ export function ModelEffortSelector() {
       >
         <Cpu size={12} />
         <span className="max-w-[120px] truncate">{modelLabel}</span>
-        <span className="text-muted/60">\u00b7</span>
+        <span className="text-muted/60">·</span>
         <span className="text-muted">{variantLabel}</span>
         <ChevronDown size={11} />
       </button>

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -7,7 +7,15 @@ import { flattenModelOptions, type ModelOption } from "@/components/settings/mod
 import { resolveSelection } from "@/lib/modelSelection";
 import type { ProviderInfo } from "@ai4s/sdk";
 
-const EFFORT_LEVELS = ["minimal", "low", "medium", "high", "extra_high", "max", "ultra"];
+const EFFORT_LEVELS: [string, string][] = [
+  ["minimal", "Minimal"],
+  ["low", "Low"],
+  ["medium", "Medium"],
+  ["high", "High"],
+  ["extra_high", "Extra High"],
+  ["max", "Max"],
+  ["ultra", "Ultra"],
+];
 
 export function ModelEffortSelector() {
   const { t } = useTranslation("session");
@@ -115,7 +123,7 @@ export function ModelEffortSelector() {
         <div
           role="menu"
           aria-label={t("composer.modelSelector.menuAria")}
-          className="absolute bottom-full left-0 z-30 mb-2 flex max-h-80 w-[28rem] rounded-card border border-border bg-surface shadow-card"
+          className="absolute bottom-full left-0 z-30 mb-2 flex max-h-80 w-72 rounded-card border border-border bg-surface shadow-card"
         >
           {/* Left: model list */}
           <div className="flex w-44 flex-col border-r border-border">
@@ -217,17 +225,17 @@ export function ModelEffortSelector() {
               {!selection?.variant && <span className="text-accent">✓</span>}
             </button>
             {/* Effort levels */}
-            {EFFORT_LEVELS.map((v) => (
+            {EFFORT_LEVELS.map(([value, label]) => (
               <button
-                key={v}
+                key={value}
                 className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
                 onClick={(e) => {
                   e.stopPropagation();
-                  handlePickVariant(v);
+                  handlePickVariant(value);
                 }}
               >
-                <span className="flex-1 capitalize text-text">{v}</span>
-                {selection?.variant === v && <span className="text-accent">✓</span>}
+                <span className="flex-1 text-text">{label}</span>
+                {selection?.variant === value && <span className="text-accent">✓</span>}
               </button>
             ))}
           </div>

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { useRuntimeStore } from "@/lib/runtime";
 import { flattenModelOptions, type ModelOption } from "@/components/settings/modelCatalog";
-import { resolveSelection, selectionAvailability } from "@/lib/modelSelection";
-import type { ModelSelection } from "@/lib/modelSelection";
+import { resolveSelection } from "@/lib/modelSelection";
 import type { ProviderInfo } from "@ai4s/sdk";
 
 const EFFORT_LEVELS = ["minimal", "low", "medium", "high", "extra_high", "max", "ultra"];
@@ -15,7 +14,6 @@ export function ModelEffortSelector() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [collapsedProviders, setCollapsedProviders] = useState<Set<string>>(new Set());
-  const [activeModel, setActiveModel] = useState<string | null>(null);
   const [thinkingOn, setThinkingOn] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -32,7 +30,9 @@ export function ModelEffortSelector() {
   const options = useMemo(() => flattenModelOptions(providers), [providers]);
   const currentModelKey = selection?.model ?? null;
   const currentOption = options.find((o) => o.key === currentModelKey) ?? null;
-  const availability = selectionAvailability(selection, providers);
+
+  // The effort panel always shows for the current selection
+  const activeOption = currentOption;
 
   // Group by provider
   const grouped = useMemo(() => {
@@ -56,7 +56,6 @@ export function ModelEffortSelector() {
     const onDown = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setOpen(false);
-        setActiveModel(null);
       }
     };
     document.addEventListener("mousedown", onDown);
@@ -70,7 +69,6 @@ export function ModelEffortSelector() {
       if (e.key === "Escape") {
         e.preventDefault();
         setOpen(false);
-        setActiveModel(null);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -79,10 +77,7 @@ export function ModelEffortSelector() {
 
   if (options.length === 0) return null;
 
-  const modelLabel = currentOption
-    ? currentOption.modelName
-    : t("composer.modelSelector.notSet");
-
+  const modelLabel = activeOption ? activeOption.modelName : t("composer.modelSelector.notSet");
   const variantLabel = selection?.variant
     ? selection.variant
     : t("composer.modelSelector.defaultVariant");
@@ -96,26 +91,23 @@ export function ModelEffortSelector() {
     });
   };
 
+  // Click model: switch to it, keep popup open so user can pick effort
   const handlePickModel = async (modelKey: string) => {
-    const newSelection: ModelSelection = { model: modelKey, variant: null };
+    if (modelKey === currentModelKey) return;
     try {
-      await setDefaultSelection(newSelection);
-      setOpen(false);
-      setActiveModel(null);
+      await setDefaultSelection({ model: modelKey, variant: null });
     } catch {
-      // error already in store.error
+      // error in store
     }
   };
 
+  // Pick effort: set on current session, then close
   const handlePickVariant = (variant: string | null) => {
-    if (!selection) return;
-    setCurrentSelection({ ...selection, variant });
+    const target = currentModelKey;
+    if (!target) return;
+    setCurrentSelection({ model: target, variant });
     setOpen(false);
-    setActiveModel(null);
   };
-
-  const isActiveCurrent = activeModel === currentModelKey;
-  const showEffortPanel = activeModel !== null;
 
   return (
     <div className="relative shrink-0" ref={containerRef}>
@@ -127,7 +119,6 @@ export function ModelEffortSelector() {
         >
           {/* Left: model list */}
           <div className="flex w-44 flex-col border-r border-border">
-            {/* Search */}
             <div className="border-b border-border p-2">
               <div className="relative">
                 <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted" />
@@ -140,7 +131,6 @@ export function ModelEffortSelector() {
                 />
               </div>
             </div>
-            {/* Providers */}
             <div className="min-h-0 flex-1 overflow-y-auto">
               {grouped.length === 0 && (
                 <div className="p-3 text-xs text-muted italic">No matches</div>
@@ -164,30 +154,17 @@ export function ModelEffortSelector() {
                     {!collapsed &&
                       models.map((opt) => {
                         const isCurrent = opt.key === currentModelKey;
-                        const isActive = opt.key === activeModel;
                         return (
                           <button
                             key={opt.key}
-                            role="menuitemradio"
-                            aria-checked={isCurrent}
                             className={cn(
                               "flex w-full items-center gap-1.5 py-1.5 pl-7 pr-2 text-left text-xs",
-                              isActive ? "bg-surface-2" : "",
-                              isCurrent ? "text-accent" : "text-text",
+                              isCurrent ? "bg-surface-2 text-accent" : "text-text hover:bg-surface-2",
                             )}
-                            onClick={() => {
-                              if (isActive) {
-                                setActiveModel(null);
-                              } else {
-                                setActiveModel(opt.key);
-                              }
-                            }}
+                            onClick={() => void handlePickModel(opt.key)}
                           >
                             <Cpu size={12} className="shrink-0 text-muted" />
                             <span className="min-w-0 flex-1 truncate">{opt.modelName}</span>
-                            {opt.variants.length > 0 && (
-                              <Brain size={10} className="shrink-0 text-muted/60" />
-                            )}
                             {isCurrent && <span className="shrink-0 text-accent">✓</span>}
                           </button>
                         );
@@ -198,93 +175,69 @@ export function ModelEffortSelector() {
             </div>
           </div>
 
-          {/* Right: effort panel (shown when a model is clicked) */}
-          {showEffortPanel && (
-            <div className="flex w-40 flex-col">
-              <div className="px-2 py-1.5 text-xs text-muted">
-                {t("composer.modelSelector.variantSection")}
-              </div>
-              {/* Thinking toggle */}
-              <button
-                className="flex w-full items-center gap-2 px-2 py-1.5 text-xs hover:bg-surface-2"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setThinkingOn((v) => !v);
-                }}
+          {/* Right: effort panel — always visible for current selection */}
+          <div className="flex w-40 flex-col">
+            <div className="px-2 py-1.5 text-xs text-muted">
+              {t("composer.modelSelector.variantSection")}
+            </div>
+            {/* Thinking toggle */}
+            <button
+              className="flex w-full items-center gap-2 px-2 py-1.5 text-xs hover:bg-surface-2"
+              onClick={(e) => {
+                e.stopPropagation();
+                setThinkingOn((v) => !v);
+              }}
+            >
+              <Brain size={12} className="text-muted" />
+              <span className="flex-1 text-text">Thinking</span>
+              <span
+                className={cn(
+                  "relative h-4 w-7 rounded-full transition-colors",
+                  thinkingOn ? "bg-accent" : "bg-muted/30",
+                )}
               >
-                <Brain size={12} className="text-muted" />
-                <span className="flex-1 text-text">Thinking</span>
                 <span
                   className={cn(
-                    "relative h-4 w-7 rounded-full transition-colors",
-                    thinkingOn ? "bg-accent" : "bg-muted/30",
+                    "absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform",
+                    thinkingOn ? "left-3.5" : "left-0.5",
                   )}
-                >
-                  <span
-                    className={cn(
-                      "absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform",
-                      thinkingOn ? "left-3.5" : "left-0.5",
-                    )}
-                  />
-                </span>
-              </button>
-              <div className="border-t border-border" />
-              {/* Effort levels */}
-              {EFFORT_LEVELS.map((v) => (
-                <button
-                  key={v}
-                  className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (isActiveCurrent) {
-                      handlePickVariant(selection?.variant === v ? null : v);
-                    } else {
-                      void setDefaultSelection({
-                        model: activeModel!,
-                        variant: v,
-                      }).then(() => {
-                        setOpen(false);
-                        setActiveModel(null);
-                      });
-                    }
-                  }}
-                >
-                  <span className="flex-1 capitalize text-text">{v}</span>
-                  {isActiveCurrent && selection?.variant === v && (
-                    <span className="text-accent">✓</span>
-                  )}
-                </button>
-              ))}
-              {/* Default (clear variant) */}
-              <div className="border-t border-border" />
+                />
+              </span>
+            </button>
+            <div className="border-t border-border" />
+            {/* Default (no variant) */}
+            <button
+              className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
+              onClick={(e) => {
+                e.stopPropagation();
+                handlePickVariant(null);
+              }}
+            >
+              <span className="flex-1 text-muted">{t("composer.modelSelector.defaultVariant")}</span>
+              {!selection?.variant && <span className="text-accent">✓</span>}
+            </button>
+            {/* Effort levels */}
+            {EFFORT_LEVELS.map((v) => (
               <button
+                key={v}
                 className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (isActiveCurrent) {
-                    handlePickVariant(null);
-                  } else {
-                    void handlePickModel(activeModel!);
-                  }
+                  handlePickVariant(v);
                 }}
               >
-                <span className="flex-1 text-muted">{t("composer.modelSelector.defaultVariant")}</span>
-                {isActiveCurrent && !selection?.variant && (
-                  <span className="text-accent">✓</span>
-                )}
+                <span className="flex-1 capitalize text-text">{v}</span>
+                {selection?.variant === v && <span className="text-accent">✓</span>}
               </button>
-            </div>
-          )}
+            ))}
+          </div>
         </div>
       )}
       <button
         aria-label={t("composer.modelSelector.aria")}
         title={t("composer.modelSelector.title")}
         className={cn(
-          "flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs",
-          availability !== "available"
-            ? "bg-warn/15 text-warn hover:bg-warn/25"
-            : "text-muted hover:bg-surface-2 hover:text-text",
+          "flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs text-muted hover:bg-surface-2 hover:text-text",
         )}
         onClick={() => setOpen((o) => !o)}
         disabled={switching}

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -1,16 +1,22 @@
-import { useMemo, useRef, useState } from "react";
-import { ChevronDown, Cpu } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Brain, ChevronDown, ChevronRight, Cpu, Search } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { useRuntimeStore } from "@/lib/runtime";
-import { flattenModelOptions } from "@/components/settings/modelCatalog";
+import { flattenModelOptions, type ModelOption } from "@/components/settings/modelCatalog";
 import { resolveSelection, selectionAvailability } from "@/lib/modelSelection";
 import type { ModelSelection } from "@/lib/modelSelection";
+import type { ProviderInfo } from "@ai4s/sdk";
 
 export function ModelEffortSelector() {
   const { t } = useTranslation("session");
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const [query, setQuery] = useState("");
+  const [collapsedProviders, setCollapsedProviders] = useState<Set<string>>(new Set());
+  const [hoveredModel, setHoveredModel] = useState<string | null>(null);
+  const [thinkingOn, setThinkingOn] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const providers = useRuntimeStore((s) => s.providers);
   const defaultSelection = useRuntimeStore((s) => s.defaultSelection);
   const sessionSelections = useRuntimeStore((s) => s.sessionSelections);
@@ -24,25 +30,77 @@ export function ModelEffortSelector() {
   const options = useMemo(() => flattenModelOptions(providers), [providers]);
   const currentModelKey = selection?.model ?? null;
   const currentOption = options.find((o) => o.key === currentModelKey) ?? null;
-  const variants = currentOption?.variants ?? [];
   const availability = selectionAvailability(selection, providers);
+
+  // Group by provider
+  const grouped = useMemo(() => {
+    const map = new Map<string, { provider: ProviderInfo; models: ModelOption[] }>();
+    for (const p of providers) {
+      const models = options.filter((o) => o.providerID === p.id);
+      const q = query.trim().toLowerCase();
+      const filtered = q
+        ? models.filter((m) =>
+            [m.modelName, m.modelID, p.name, p.id].join(" ").toLowerCase().includes(q),
+          )
+        : models;
+      if (filtered.length > 0) map.set(p.id, { provider: p, models: filtered });
+    }
+    return Array.from(map.values());
+  }, [providers, options, query]);
+
+  // Click outside to close
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setHoveredModel(null);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // Esc to close
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        setHoveredModel(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
 
   // ponytail: only show when connected and has at least one model option
   if (options.length === 0) return null;
 
   const modelLabel = currentOption
-    ? `${currentOption.modelName}${currentOption.providerName ? ` · ${currentOption.providerName}` : ""}`
+    ? currentOption.modelName
     : t("composer.modelSelector.notSet");
 
   const variantLabel = selection?.variant
     ? selection.variant
     : t("composer.modelSelector.defaultVariant");
 
+  const toggleProvider = (id: string) => {
+    setCollapsedProviders((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
   const handlePickModel = async (modelKey: string) => {
     const newSelection: ModelSelection = { model: modelKey, variant: null };
     try {
       await setDefaultSelection(newSelection);
       setOpen(false);
+      setHoveredModel(null);
     } catch {
       // error already in store.error
     }
@@ -51,79 +109,164 @@ export function ModelEffortSelector() {
   const handlePickVariant = (variant: string | null) => {
     if (!selection) return;
     setCurrentSelection({ ...selection, variant });
-    setOpen(false);
+    setHoveredModel(null);
   };
 
+  const hoveredOption = hoveredModel ? options.find((o) => o.key === hoveredModel) : null;
+  const hoveredVariants = hoveredOption?.variants ?? [];
+  const isHoveredCurrent = hoveredModel === currentModelKey;
+
   return (
-    <div className="relative shrink-0" ref={ref}>
+    <div className="relative shrink-0" ref={containerRef}>
       {open && (
         <div
           role="menu"
           aria-label={t("composer.modelSelector.menuAria")}
-          className="absolute bottom-full left-0 z-20 mb-2 w-80 rounded-card border border-border bg-surface p-1 shadow-card"
+          className="absolute bottom-full left-0 z-30 mb-2 w-72 rounded-card border border-border bg-surface shadow-card"
         >
-          <div className="px-2 pb-1 pt-1.5 text-xs text-muted">
-            {t("composer.modelSelector.modelSection")}
+          {/* Search */}
+          <div className="border-b border-border p-2">
+            <div className="relative">
+              <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted" />
+              <input
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t("composer.modelSelector.modelSection")}
+                className="w-full rounded-input bg-surface-2 py-1 pl-7 pr-2 text-xs text-text outline-none placeholder:text-muted"
+              />
+            </div>
           </div>
-          <div className="max-h-48 overflow-y-auto">
-            {options.map((opt) => (
-              <button
-                key={opt.key}
-                role="menuitemradio"
-                aria-checked={opt.key === currentModelKey}
-                className="flex w-full items-center gap-2 rounded-input px-2 py-1.5 text-left hover:bg-surface-2"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  if (opt.key !== currentModelKey) void handlePickModel(opt.key);
-                }}
-              >
-                <Cpu size={13} className="shrink-0 text-muted" />
-                <span className="min-w-0 flex-1 truncate text-xs text-text">
-                  {opt.modelName}
-                  <span className="text-muted"> · {opt.providerName}</span>
-                </span>
-                {opt.key === currentModelKey && (
-                  <span className="shrink-0 text-xs text-accent">✓</span>
-                )}
-              </button>
-            ))}
+
+          {/* Model list grouped by provider */}
+          <div className="relative max-h-64 overflow-y-auto">
+            {grouped.length === 0 && (
+              <div className="p-3 text-xs text-muted italic">No matches</div>
+            )}
+            {grouped.map(({ provider, models }) => {
+              const collapsed = collapsedProviders.has(provider.id);
+              return (
+                <div key={provider.id}>
+                  <button
+                    onClick={() => toggleProvider(provider.id)}
+                    className="flex w-full items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted hover:bg-surface-2"
+                  >
+                    {collapsed ? (
+                      <ChevronRight size={11} className="shrink-0" />
+                    ) : (
+                      <ChevronDown size={11} className="shrink-0" />
+                    )}
+                    <span className="truncate">{provider.name}</span>
+                    <span className="ml-auto text-muted/60">{models.length}</span>
+                  </button>
+                  {!collapsed &&
+                    models.map((opt) => {
+                      const isCurrent = opt.key === currentModelKey;
+                      const isHovered = opt.key === hoveredModel;
+                      return (
+                        <div
+                          key={opt.key}
+                          className="relative"
+                          onMouseEnter={() => setHoveredModel(opt.key)}
+                          onMouseLeave={() => setHoveredModel(null)}
+                        >
+                          <button
+                            role="menuitemradio"
+                            aria-checked={isCurrent}
+                            className={cn(
+                              "flex w-full items-center gap-2 py-1.5 pl-7 pr-2 text-left text-xs hover:bg-surface-2",
+                              isCurrent && "text-accent",
+                            )}
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              if (!isCurrent) void handlePickModel(opt.key);
+                            }}
+                          >
+                            <Cpu size={12} className="shrink-0 text-muted" />
+                            <span className="min-w-0 flex-1 truncate">{opt.modelName}</span>
+                            {opt.variants.length > 0 && (
+                              <Brain size={10} className="shrink-0 text-muted/60" />
+                            )}
+                            {isCurrent && (
+                              <span className="shrink-0 text-accent">✓</span>
+                            )}
+                          </button>
+
+                          {/* Thinking/effort popover on hover */}
+                          {isHovered && (
+                            <div className="absolute left-full top-0 z-40 ml-1 w-56 rounded-card border border-border bg-surface shadow-card">
+                              <div className="px-2 py-1.5 text-xs text-muted">
+                                {t("composer.modelSelector.variantSection")}
+                              </div>
+                              {/* Thinking toggle */}
+                              <button
+                                className="flex w-full items-center gap-2 px-2 py-1.5 text-xs hover:bg-surface-2"
+                                onMouseDown={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  setThinkingOn((v) => !v);
+                                }}
+                              >
+                                <span className="flex-1 text-text">Thinking</span>
+                                <span
+                                  className={cn(
+                                    "relative h-4 w-7 rounded-full transition-colors",
+                                    thinkingOn ? "bg-accent" : "bg-muted/30",
+                                  )}
+                                >
+                                  <span
+                                    className={cn(
+                                      "absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform",
+                                      thinkingOn ? "left-3.5" : "left-0.5",
+                                    )}
+                                  />
+                                </span>
+                              </button>
+                              {/* Effort levels */}
+                              {hoveredVariants.length > 0 ? (
+                                hoveredVariants.map((v) => (
+                                  <button
+                                    key={v}
+                                    className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
+                                    onMouseDown={(e) => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      if (isHoveredCurrent) {
+                                        handlePickVariant(
+                                          selection?.variant === v ? null : v,
+                                        );
+                                      } else {
+                                        // Select model + variant
+                                        void setDefaultSelection({
+                                          model: opt.key,
+                                          variant: v,
+                                        }).then(() => {
+                                          setOpen(false);
+                                          setHoveredModel(null);
+                                        });
+                                      }
+                                    }}
+                                  >
+                                    <span className="flex-1 capitalize text-text">{v}</span>
+                                    {isHoveredCurrent && selection?.variant === v && (
+                                      <span className="text-accent">✓</span>
+                                    )}
+                                  </button>
+                                ))
+                              ) : (
+                                <div className="px-2 py-1 text-xs text-muted italic">
+                                  No variants
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                </div>
+              );
+            })}
           </div>
-          {variants.length > 0 && (
-            <>
-              <div className="mt-1 border-t border-border px-2 pb-1 pt-1.5 text-xs text-muted">
-                {t("composer.modelSelector.variantSection")}
-              </div>
-              <button
-                role="menuitemradio"
-                aria-checked={!selection?.variant}
-                className="flex w-full items-center gap-2 rounded-input px-2 py-1.5 text-left hover:bg-surface-2"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  handlePickVariant(null);
-                }}
-              >
-                <span className="min-w-0 flex-1 truncate text-xs text-text">
-                  {t("composer.modelSelector.defaultVariant")}
-                </span>
-                {!selection?.variant && <span className="shrink-0 text-xs text-accent">✓</span>}
-              </button>
-              {variants.map((v) => (
-                <button
-                  key={v}
-                  role="menuitemradio"
-                  aria-checked={selection?.variant === v}
-                  className="flex w-full items-center gap-2 rounded-input px-2 py-1.5 text-left hover:bg-surface-2"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    handlePickVariant(v);
-                  }}
-                >
-                  <span className="min-w-0 flex-1 truncate text-xs text-text">{v}</span>
-                  {selection?.variant === v && <span className="shrink-0 text-xs text-accent">✓</span>}
-                </button>
-              ))}
-            </>
-          )}
         </div>
       )}
       <button
@@ -139,7 +282,7 @@ export function ModelEffortSelector() {
         disabled={switching}
       >
         <Cpu size={12} />
-        <span className="max-w-[120px] truncate">{modelLabel}</span>
+        <span className="max-w-[100px] truncate">{modelLabel}</span>
         <span className="text-muted/60">·</span>
         <span className="text-muted">{variantLabel}</span>
         <ChevronDown size={11} />

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -77,7 +77,6 @@ export function ModelEffortSelector() {
     return () => window.removeEventListener("keydown", onKey);
   }, [open]);
 
-  // ponytail: only show when connected and has at least one model option
   if (options.length === 0) return null;
 
   const modelLabel = currentOption
@@ -111,10 +110,10 @@ export function ModelEffortSelector() {
   const handlePickVariant = (variant: string | null) => {
     if (!selection) return;
     setCurrentSelection({ ...selection, variant });
-    setHoveredModel(null);
   };
 
   const isHoveredCurrent = hoveredModel === currentModelKey;
+  const showEffortPanel = hoveredModel !== null;
 
   return (
     <div className="relative shrink-0" ref={containerRef}>
@@ -122,61 +121,59 @@ export function ModelEffortSelector() {
         <div
           role="menu"
           aria-label={t("composer.modelSelector.menuAria")}
-          className="absolute bottom-full left-0 z-30 mb-2 w-72 rounded-card border border-border bg-surface shadow-card"
+          className="absolute bottom-full left-0 z-30 mb-2 flex max-h-80 w-[28rem] rounded-card border border-border bg-surface shadow-card"
         >
-          {/* Search */}
-          <div className="border-b border-border p-2">
-            <div className="relative">
-              <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted" />
-              <input
-                autoFocus
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder={t("composer.modelSelector.modelSection")}
-                className="w-full rounded-input bg-surface-2 py-1 pl-7 pr-2 text-xs text-text outline-none placeholder:text-muted"
-              />
+          {/* Left: model list */}
+          <div className="flex w-44 flex-col border-r border-border">
+            {/* Search */}
+            <div className="border-b border-border p-2">
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted" />
+                <input
+                  autoFocus
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search"
+                  className="w-full rounded-input bg-surface-2 py-1 pl-7 pr-2 text-xs text-text outline-none placeholder:text-muted"
+                />
+              </div>
             </div>
-          </div>
-
-          {/* Model list grouped by provider */}
-          <div className="relative max-h-64 overflow-y-auto">
-            {grouped.length === 0 && (
-              <div className="p-3 text-xs text-muted italic">No matches</div>
-            )}
-            {grouped.map(({ provider, models }) => {
-              const collapsed = collapsedProviders.has(provider.id);
-              return (
-                <div key={provider.id}>
-                  <button
-                    onClick={() => toggleProvider(provider.id)}
-                    className="flex w-full items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted hover:bg-surface-2"
-                  >
-                    {collapsed ? (
-                      <ChevronRight size={11} className="shrink-0" />
-                    ) : (
-                      <ChevronDown size={11} className="shrink-0" />
-                    )}
-                    <span className="truncate">{provider.name}</span>
-                    <span className="ml-auto text-muted/60">{models.length}</span>
-                  </button>
-                  {!collapsed &&
-                    models.map((opt) => {
-                      const isCurrent = opt.key === currentModelKey;
-                      const isHovered = opt.key === hoveredModel;
-                      return (
-                        <div
-                          key={opt.key}
-                          className="relative"
-                          onMouseEnter={() => setHoveredModel(opt.key)}
-                          onMouseLeave={() => setHoveredModel(null)}
-                        >
+            {/* Providers */}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {grouped.length === 0 && (
+                <div className="p-3 text-xs text-muted italic">No matches</div>
+              )}
+              {grouped.map(({ provider, models }) => {
+                const collapsed = collapsedProviders.has(provider.id);
+                return (
+                  <div key={provider.id}>
+                    <button
+                      onClick={() => toggleProvider(provider.id)}
+                      className="flex w-full items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted hover:bg-surface-2"
+                    >
+                      {collapsed ? (
+                        <ChevronRight size={11} className="shrink-0" />
+                      ) : (
+                        <ChevronDown size={11} className="shrink-0" />
+                      )}
+                      <span className="truncate">{provider.name}</span>
+                      <span className="ml-auto text-muted/60">{models.length}</span>
+                    </button>
+                    {!collapsed &&
+                      models.map((opt) => {
+                        const isCurrent = opt.key === currentModelKey;
+                        const isHovered = opt.key === hoveredModel;
+                        return (
                           <button
+                            key={opt.key}
                             role="menuitemradio"
                             aria-checked={isCurrent}
                             className={cn(
-                              "flex w-full items-center gap-2 py-1.5 pl-7 pr-2 text-left text-xs hover:bg-surface-2",
-                              isCurrent && "text-accent",
+                              "flex w-full items-center gap-1.5 py-1.5 pl-7 pr-2 text-left text-xs",
+                              isHovered ? "bg-surface-2" : "",
+                              isCurrent ? "text-accent" : "text-text",
                             )}
+                            onMouseEnter={() => setHoveredModel(opt.key)}
                             onMouseDown={(e) => {
                               e.preventDefault();
                               if (!isCurrent) void handlePickModel(opt.key);
@@ -184,83 +181,77 @@ export function ModelEffortSelector() {
                           >
                             <Cpu size={12} className="shrink-0 text-muted" />
                             <span className="min-w-0 flex-1 truncate">{opt.modelName}</span>
-                            {opt.variants.length > 0 && (
-                              <Brain size={10} className="shrink-0 text-muted/60" />
-                            )}
-                            {isCurrent && (
-                              <span className="shrink-0 text-accent">✓</span>
-                            )}
+                            {isCurrent && <span className="shrink-0 text-accent">✓</span>}
                           </button>
-
-                          {/* Thinking/effort popover on hover */}
-                          {isHovered && (
-                            <div className="absolute left-full top-0 z-40 ml-1 w-56 rounded-card border border-border bg-surface shadow-card">
-                              <div className="px-2 py-1.5 text-xs text-muted">
-                                {t("composer.modelSelector.variantSection")}
-                              </div>
-                              {/* Thinking toggle */}
-                              <button
-                                className="flex w-full items-center gap-2 px-2 py-1.5 text-xs hover:bg-surface-2"
-                                onMouseDown={(e) => {
-                                  e.preventDefault();
-                                  e.stopPropagation();
-                                  setThinkingOn((v) => !v);
-                                }}
-                              >
-                                <span className="flex-1 text-text">Thinking</span>
-                                <span
-                                  className={cn(
-                                    "relative h-4 w-7 rounded-full transition-colors",
-                                    thinkingOn ? "bg-accent" : "bg-muted/30",
-                                  )}
-                                >
-                                  <span
-                                    className={cn(
-                                      "absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform",
-                                      thinkingOn ? "left-3.5" : "left-0.5",
-                                    )}
-                                  />
-                                </span>
-                              </button>
-                              {/* Effort levels */}
-                              {EFFORT_LEVELS.map((v) => (
-                                <button
-                                  key={v}
-                                  className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
-                                  onMouseDown={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    if (isHoveredCurrent) {
-                                      handlePickVariant(
-                                        selection?.variant === v ? null : v,
-                                      );
-                                    } else {
-                                      // Select model + variant
-                                      void setDefaultSelection({
-                                        model: hoveredModel!,
-                                        variant: v,
-                                      }).then(() => {
-                                        setOpen(false);
-                                        setHoveredModel(null);
-                                      });
-                                    }
-                                  }}
-                                >
-                                  <span className="flex-1 capitalize text-text">{v}</span>
-                                  {isHoveredCurrent && selection?.variant === v && (
-                                    <span className="text-accent">✓</span>
-                                  )}
-                                </button>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                </div>
-              );
-            })}
+                        );
+                      })}
+                  </div>
+                );
+              })}
+            </div>
           </div>
+
+          {/* Right: effort panel (shown when a model is hovered) */}
+          {showEffortPanel && (
+            <div className="flex w-40 flex-col">
+              <div className="px-2 py-1.5 text-xs text-muted">
+                {t("composer.modelSelector.variantSection")}
+              </div>
+              {/* Thinking toggle */}
+              <button
+                className="flex w-full items-center gap-2 px-2 py-1.5 text-xs hover:bg-surface-2"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setThinkingOn((v) => !v);
+                }}
+              >
+                <Brain size={12} className="text-muted" />
+                <span className="flex-1 text-text">Thinking</span>
+                <span
+                  className={cn(
+                    "relative h-4 w-7 rounded-full transition-colors",
+                    thinkingOn ? "bg-accent" : "bg-muted/30",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform",
+                      thinkingOn ? "left-3.5" : "left-0.5",
+                    )}
+                  />
+                </span>
+              </button>
+              <div className="border-t border-border" />
+              {/* Effort levels */}
+              {EFFORT_LEVELS.map((v) => (
+                <button
+                  key={v}
+                  className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (isHoveredCurrent) {
+                      handlePickVariant(selection?.variant === v ? null : v);
+                    } else {
+                      void setDefaultSelection({
+                        model: hoveredModel!,
+                        variant: v,
+                      }).then(() => {
+                        setOpen(false);
+                        setHoveredModel(null);
+                      });
+                    }
+                  }}
+                >
+                  <span className="flex-1 capitalize text-text">{v}</span>
+                  {isHoveredCurrent && selection?.variant === v && (
+                    <span className="text-accent">✓</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       )}
       <button

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -87,7 +87,7 @@ export function ModelEffortSelector() {
 
   const modelLabel = activeOption ? activeOption.modelName : t("composer.modelSelector.notSet");
   const variantLabel = selection?.variant
-    ? selection.variant
+    ? EFFORT_LEVELS.find(([v]) => v === selection.variant)?.[1] ?? selection.variant
     : t("composer.modelSelector.defaultVariant");
 
   const toggleProvider = (id: string) => {
@@ -123,7 +123,7 @@ export function ModelEffortSelector() {
         <div
           role="menu"
           aria-label={t("composer.modelSelector.menuAria")}
-          className="absolute bottom-full left-0 z-30 mb-2 flex max-h-80 w-72 rounded-card border border-border bg-surface shadow-card"
+          className="absolute bottom-full left-0 z-30 mb-2 flex max-h-80 w-80 overflow-hidden rounded-card border border-border bg-surface shadow-card"
         >
           {/* Left: model list */}
           <div className="flex w-44 flex-col border-r border-border">
@@ -149,7 +149,7 @@ export function ModelEffortSelector() {
                   <div key={provider.id}>
                     <button
                       onClick={() => toggleProvider(provider.id)}
-                      className="flex w-full items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted hover:bg-surface-2"
+                      className="flex w-full items-center gap-1 px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted hover:bg-surface-2"
                     >
                       {collapsed ? (
                         <ChevronRight size={11} className="shrink-0" />
@@ -185,7 +185,7 @@ export function ModelEffortSelector() {
 
           {/* Right: effort panel — always visible for current selection */}
           <div className="flex w-40 flex-col">
-            <div className="px-2 py-1.5 text-xs text-muted">
+            <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted">
               {t("composer.modelSelector.variantSection")}
             </div>
             {/* Thinking toggle */}

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useRef, useState } from "react";
+import { ChevronDown, Cpu } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { useRuntimeStore } from "@/lib/runtime";
+import { flattenModelOptions } from "@/components/settings/modelCatalog";
+import { resolveSelection, selectionAvailability } from "@/lib/modelSelection";
+import type { ModelSelection } from "@/lib/modelSelection";
+
+export function ModelEffortSelector() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const providers = useRuntimeStore((s) => s.providers);
+  const defaultSelection = useRuntimeStore((s) => s.defaultSelection);
+  const sessionSelections = useRuntimeStore((s) => s.sessionSelections);
+  const draftSelection = useRuntimeStore((s) => s.draftSelection);
+  const currentId = useRuntimeStore((s) => s.currentId);
+  const switching = useRuntimeStore((s) => s.switching);
+  const setCurrentSelection = useRuntimeStore((s) => s.setCurrentSelection);
+  const setDefaultSelection = useRuntimeStore((s) => s.setDefaultSelection);
+
+  const selection = resolveSelection({ currentId, defaultSelection, sessionSelections, draftSelection });
+  const options = useMemo(() => flattenModelOptions(providers), [providers]);
+  const currentModelKey = selection?.model ?? null;
+  const currentOption = options.find((o) => o.key === currentModelKey) ?? null;
+  const variants = currentOption?.variants ?? [];
+  const availability = selectionAvailability(selection, providers);
+
+  // ponytail: only show when connected and has at least one model option
+  if (options.length === 0) return null;
+
+  const modelLabel = currentOption
+    ? `${currentOption.modelName}${currentOption.providerName ? ` \u00b7 ${currentOption.providerName}` : ""}`
+    : "Not set";
+
+  const variantLabel = selection?.variant
+    ? selection.variant
+    : "Default";
+
+  const handlePickModel = async (modelKey: string) => {
+    const newSelection: ModelSelection = { model: modelKey, variant: null };
+    try {
+      await setDefaultSelection(newSelection);
+      setOpen(false);
+    } catch {
+      // error already in store.error
+    }
+  };
+
+  const handlePickVariant = (variant: string | null) => {
+    if (!selection) return;
+    setCurrentSelection({ ...selection, variant });
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative shrink-0" ref={ref}>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Model selector"
+          className="absolute bottom-full left-0 z-20 mb-2 w-80 rounded-card border border-border bg-surface p-1 shadow-card"
+        >
+          <div className="px-2 pb-1 pt-1.5 text-xs text-muted">Model</div>
+          <div className="max-h-48 overflow-y-auto">
+            {options.map((opt) => (
+              <button
+                key={opt.key}
+                role="menuitemradio"
+                aria-checked={opt.key === currentModelKey}
+                className="flex w-full items-center gap-2 rounded-input px-2 py-1.5 text-left hover:bg-surface-2"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  if (opt.key !== currentModelKey) void handlePickModel(opt.key);
+                }}
+              >
+                <Cpu size={13} className="shrink-0 text-muted" />
+                <span className="min-w-0 flex-1 truncate text-xs text-text">
+                  {opt.modelName}
+                  <span className="text-muted"> \u00b7 {opt.providerName}</span>
+                </span>
+                {opt.key === currentModelKey && (
+                  <span className="shrink-0 text-xs text-accent">\u2713</span>
+                )}
+              </button>
+            ))}
+          </div>
+          {variants.length > 0 && (
+            <>
+              <div className="mt-1 border-t border-border px-2 pb-1 pt-1.5 text-xs text-muted">Reasoning</div>
+              <button
+                role="menuitemradio"
+                aria-checked={!selection?.variant}
+                className="flex w-full items-center gap-2 rounded-input px-2 py-1.5 text-left hover:bg-surface-2"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handlePickVariant(null);
+                }}
+              >
+                <span className="min-w-0 flex-1 truncate text-xs text-text">Default</span>
+                {!selection?.variant && <span className="shrink-0 text-xs text-accent">\u2713</span>}
+              </button>
+              {variants.map((v) => (
+                <button
+                  key={v}
+                  role="menuitemradio"
+                  aria-checked={selection?.variant === v}
+                  className="flex w-full items-center gap-2 rounded-input px-2 py-1.5 text-left hover:bg-surface-2"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handlePickVariant(v);
+                  }}
+                >
+                  <span className="min-w-0 flex-1 truncate text-xs text-text">{v}</span>
+                  {selection?.variant === v && <span className="shrink-0 text-xs text-accent">\u2713</span>}
+                </button>
+              ))}
+            </>
+          )}
+        </div>
+      )}
+      <button
+        aria-label="Model selector"
+        title="Model and reasoning level"
+        className={cn(
+          "flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs",
+          availability !== "available"
+            ? "bg-warn/15 text-warn hover:bg-warn/25"
+            : "text-muted hover:bg-surface-2 hover:text-text",
+        )}
+        onClick={() => setOpen((o) => !o)}
+        disabled={switching}
+      >
+        <Cpu size={12} />
+        <span className="max-w-[120px] truncate">{modelLabel}</span>
+        <span className="text-muted/60">\u00b7</span>
+        <span className="text-muted">{variantLabel}</span>
+        <ChevronDown size={11} />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -8,6 +8,8 @@ import { resolveSelection, selectionAvailability } from "@/lib/modelSelection";
 import type { ModelSelection } from "@/lib/modelSelection";
 import type { ProviderInfo } from "@ai4s/sdk";
 
+const EFFORT_LEVELS = ["minimal", "low", "medium", "high", "extra_high", "max", "ultra"];
+
 export function ModelEffortSelector() {
   const { t } = useTranslation("session");
   const [open, setOpen] = useState(false);
@@ -112,8 +114,6 @@ export function ModelEffortSelector() {
     setHoveredModel(null);
   };
 
-  const hoveredOption = hoveredModel ? options.find((o) => o.key === hoveredModel) : null;
-  const hoveredVariants = hoveredOption?.variants ?? [];
   const isHoveredCurrent = hoveredModel === currentModelKey;
 
   return (
@@ -223,41 +223,35 @@ export function ModelEffortSelector() {
                                 </span>
                               </button>
                               {/* Effort levels */}
-                              {hoveredVariants.length > 0 ? (
-                                hoveredVariants.map((v) => (
-                                  <button
-                                    key={v}
-                                    className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
-                                    onMouseDown={(e) => {
-                                      e.preventDefault();
-                                      e.stopPropagation();
-                                      if (isHoveredCurrent) {
-                                        handlePickVariant(
-                                          selection?.variant === v ? null : v,
-                                        );
-                                      } else {
-                                        // Select model + variant
-                                        void setDefaultSelection({
-                                          model: opt.key,
-                                          variant: v,
-                                        }).then(() => {
-                                          setOpen(false);
-                                          setHoveredModel(null);
-                                        });
-                                      }
-                                    }}
-                                  >
-                                    <span className="flex-1 capitalize text-text">{v}</span>
-                                    {isHoveredCurrent && selection?.variant === v && (
-                                      <span className="text-accent">✓</span>
-                                    )}
-                                  </button>
-                                ))
-                              ) : (
-                                <div className="px-2 py-1 text-xs text-muted italic">
-                                  No variants
-                                </div>
-                              )}
+                              {EFFORT_LEVELS.map((v) => (
+                                <button
+                                  key={v}
+                                  className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
+                                  onMouseDown={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    if (isHoveredCurrent) {
+                                      handlePickVariant(
+                                        selection?.variant === v ? null : v,
+                                      );
+                                    } else {
+                                      // Select model + variant
+                                      void setDefaultSelection({
+                                        model: hoveredModel!,
+                                        variant: v,
+                                      }).then(() => {
+                                        setOpen(false);
+                                        setHoveredModel(null);
+                                      });
+                                    }
+                                  }}
+                                >
+                                  <span className="flex-1 capitalize text-text">{v}</span>
+                                  {isHoveredCurrent && selection?.variant === v && (
+                                    <span className="text-accent">✓</span>
+                                  )}
+                                </button>
+                              ))}
                             </div>
                           )}
                         </div>

--- a/apps/desktop/src/components/thread/ModelEffortSelector.tsx
+++ b/apps/desktop/src/components/thread/ModelEffortSelector.tsx
@@ -15,7 +15,7 @@ export function ModelEffortSelector() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [collapsedProviders, setCollapsedProviders] = useState<Set<string>>(new Set());
-  const [hoveredModel, setHoveredModel] = useState<string | null>(null);
+  const [activeModel, setActiveModel] = useState<string | null>(null);
   const [thinkingOn, setThinkingOn] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -56,7 +56,7 @@ export function ModelEffortSelector() {
     const onDown = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setOpen(false);
-        setHoveredModel(null);
+        setActiveModel(null);
       }
     };
     document.addEventListener("mousedown", onDown);
@@ -70,7 +70,7 @@ export function ModelEffortSelector() {
       if (e.key === "Escape") {
         e.preventDefault();
         setOpen(false);
-        setHoveredModel(null);
+        setActiveModel(null);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -101,7 +101,7 @@ export function ModelEffortSelector() {
     try {
       await setDefaultSelection(newSelection);
       setOpen(false);
-      setHoveredModel(null);
+      setActiveModel(null);
     } catch {
       // error already in store.error
     }
@@ -110,10 +110,12 @@ export function ModelEffortSelector() {
   const handlePickVariant = (variant: string | null) => {
     if (!selection) return;
     setCurrentSelection({ ...selection, variant });
+    setOpen(false);
+    setActiveModel(null);
   };
 
-  const isHoveredCurrent = hoveredModel === currentModelKey;
-  const showEffortPanel = hoveredModel !== null;
+  const isActiveCurrent = activeModel === currentModelKey;
+  const showEffortPanel = activeModel !== null;
 
   return (
     <div className="relative shrink-0" ref={containerRef}>
@@ -162,7 +164,7 @@ export function ModelEffortSelector() {
                     {!collapsed &&
                       models.map((opt) => {
                         const isCurrent = opt.key === currentModelKey;
-                        const isHovered = opt.key === hoveredModel;
+                        const isActive = opt.key === activeModel;
                         return (
                           <button
                             key={opt.key}
@@ -170,17 +172,22 @@ export function ModelEffortSelector() {
                             aria-checked={isCurrent}
                             className={cn(
                               "flex w-full items-center gap-1.5 py-1.5 pl-7 pr-2 text-left text-xs",
-                              isHovered ? "bg-surface-2" : "",
+                              isActive ? "bg-surface-2" : "",
                               isCurrent ? "text-accent" : "text-text",
                             )}
-                            onMouseEnter={() => setHoveredModel(opt.key)}
-                            onMouseDown={(e) => {
-                              e.preventDefault();
-                              if (!isCurrent) void handlePickModel(opt.key);
+                            onClick={() => {
+                              if (isActive) {
+                                setActiveModel(null);
+                              } else {
+                                setActiveModel(opt.key);
+                              }
                             }}
                           >
                             <Cpu size={12} className="shrink-0 text-muted" />
                             <span className="min-w-0 flex-1 truncate">{opt.modelName}</span>
+                            {opt.variants.length > 0 && (
+                              <Brain size={10} className="shrink-0 text-muted/60" />
+                            )}
                             {isCurrent && <span className="shrink-0 text-accent">✓</span>}
                           </button>
                         );
@@ -191,7 +198,7 @@ export function ModelEffortSelector() {
             </div>
           </div>
 
-          {/* Right: effort panel (shown when a model is hovered) */}
+          {/* Right: effort panel (shown when a model is clicked) */}
           {showEffortPanel && (
             <div className="flex w-40 flex-col">
               <div className="px-2 py-1.5 text-xs text-muted">
@@ -200,8 +207,7 @@ export function ModelEffortSelector() {
               {/* Thinking toggle */}
               <button
                 className="flex w-full items-center gap-2 px-2 py-1.5 text-xs hover:bg-surface-2"
-                onMouseDown={(e) => {
-                  e.preventDefault();
+                onClick={(e) => {
                   e.stopPropagation();
                   setThinkingOn((v) => !v);
                 }}
@@ -228,28 +234,45 @@ export function ModelEffortSelector() {
                 <button
                   key={v}
                   className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
+                  onClick={(e) => {
                     e.stopPropagation();
-                    if (isHoveredCurrent) {
+                    if (isActiveCurrent) {
                       handlePickVariant(selection?.variant === v ? null : v);
                     } else {
                       void setDefaultSelection({
-                        model: hoveredModel!,
+                        model: activeModel!,
                         variant: v,
                       }).then(() => {
                         setOpen(false);
-                        setHoveredModel(null);
+                        setActiveModel(null);
                       });
                     }
                   }}
                 >
                   <span className="flex-1 capitalize text-text">{v}</span>
-                  {isHoveredCurrent && selection?.variant === v && (
+                  {isActiveCurrent && selection?.variant === v && (
                     <span className="text-accent">✓</span>
                   )}
                 </button>
               ))}
+              {/* Default (clear variant) */}
+              <div className="border-t border-border" />
+              <button
+                className="flex w-full items-center gap-2 px-2 py-1 text-xs hover:bg-surface-2"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (isActiveCurrent) {
+                    handlePickVariant(null);
+                  } else {
+                    void handlePickModel(activeModel!);
+                  }
+                }}
+              >
+                <span className="flex-1 text-muted">{t("composer.modelSelector.defaultVariant")}</span>
+                {isActiveCurrent && !selection?.variant && (
+                  <span className="text-accent">✓</span>
+                )}
+              </button>
             </div>
           )}
         </div>

--- a/apps/desktop/src/i18n/locales/de/session.json
+++ b/apps/desktop/src/i18n/locales/de/session.json
@@ -68,6 +68,16 @@
     "error": {
       "paste": "Einfügen konnte nicht gespeichert werden: {{message}}",
       "addFiles": "Dateien konnten nicht hinzugefügt werden: {{message}}"
+    },
+    "modelSelector": {
+      "aria": "Model selector",
+      "title": "Model and reasoning level",
+      "menuAria": "Model selector",
+      "menuTitle": "Select model",
+      "modelSection": "Model",
+      "variantSection": "Reasoning",
+      "defaultVariant": "Default",
+      "notSet": "Not set"
     }
   },
   "localCommand": {

--- a/apps/desktop/src/i18n/locales/en/session.json
+++ b/apps/desktop/src/i18n/locales/en/session.json
@@ -68,6 +68,16 @@
     "error": {
       "paste": "Could not save paste: {{message}}",
       "addFiles": "Could not add files: {{message}}"
+    },
+    "modelSelector": {
+      "aria": "Model selector",
+      "title": "Model and reasoning level",
+      "menuAria": "Model selector",
+      "menuTitle": "Select model",
+      "modelSection": "Model",
+      "variantSection": "Reasoning",
+      "defaultVariant": "Default",
+      "notSet": "Not set"
     }
   },
   "localCommand": {

--- a/apps/desktop/src/i18n/locales/es/session.json
+++ b/apps/desktop/src/i18n/locales/es/session.json
@@ -68,6 +68,16 @@
     "error": {
       "paste": "No se pudo guardar el contenido pegado: {{message}}",
       "addFiles": "No se pudieron añadir los archivos: {{message}}"
+    },
+    "modelSelector": {
+      "aria": "Model selector",
+      "title": "Model and reasoning level",
+      "menuAria": "Model selector",
+      "menuTitle": "Select model",
+      "modelSection": "Model",
+      "variantSection": "Reasoning",
+      "defaultVariant": "Default",
+      "notSet": "Not set"
     }
   },
   "localCommand": {

--- a/apps/desktop/src/i18n/locales/fr/session.json
+++ b/apps/desktop/src/i18n/locales/fr/session.json
@@ -68,6 +68,16 @@
     "error": {
       "paste": "Impossible d'enregistrer le collage : {{message}}",
       "addFiles": "Impossible d'ajouter les fichiers : {{message}}"
+    },
+    "modelSelector": {
+      "aria": "Model selector",
+      "title": "Model and reasoning level",
+      "menuAria": "Model selector",
+      "menuTitle": "Select model",
+      "modelSection": "Model",
+      "variantSection": "Reasoning",
+      "defaultVariant": "Default",
+      "notSet": "Not set"
     }
   },
   "localCommand": {

--- a/apps/desktop/src/i18n/locales/ja/session.json
+++ b/apps/desktop/src/i18n/locales/ja/session.json
@@ -68,6 +68,16 @@
     "error": {
       "paste": "貼り付けを保存できませんでした: {{message}}",
       "addFiles": "ファイルを追加できませんでした: {{message}}"
+    },
+    "modelSelector": {
+      "aria": "モデル選択",
+      "title": "モデルと推論レベル",
+      "menuAria": "モデル選択",
+      "menuTitle": "モデルを選択",
+      "modelSection": "モデル",
+      "variantSection": "推論レベル",
+      "defaultVariant": "デフォルト",
+      "notSet": "未設定"
     }
   },
   "localCommand": {

--- a/apps/desktop/src/i18n/locales/ko/session.json
+++ b/apps/desktop/src/i18n/locales/ko/session.json
@@ -68,6 +68,16 @@
     "error": {
       "paste": "붙여넣기를 저장할 수 없습니다: {{message}}",
       "addFiles": "파일을 추가할 수 없습니다: {{message}}"
+    },
+    "modelSelector": {
+      "aria": "Model selector",
+      "title": "Model and reasoning level",
+      "menuAria": "Model selector",
+      "menuTitle": "Select model",
+      "modelSection": "Model",
+      "variantSection": "Reasoning",
+      "defaultVariant": "Default",
+      "notSet": "Not set"
     }
   },
   "localCommand": {

--- a/apps/desktop/src/i18n/locales/zh-Hans/session.json
+++ b/apps/desktop/src/i18n/locales/zh-Hans/session.json
@@ -68,6 +68,16 @@
     "error": {
       "paste": "无法保存粘贴内容：{{message}}",
       "addFiles": "无法添加文件：{{message}}"
+    },
+    "modelSelector": {
+      "aria": "模型选择",
+      "title": "模型与推理级别",
+      "menuAria": "模型选择",
+      "menuTitle": "选择模型",
+      "modelSection": "模型",
+      "variantSection": "推理级别",
+      "defaultVariant": "默认",
+      "notSet": "未设置"
     }
   },
   "localCommand": {

--- a/apps/desktop/src/lib/modelSelection.test.ts
+++ b/apps/desktop/src/lib/modelSelection.test.ts
@@ -61,11 +61,18 @@ describe("selectionAvailability", () => {
     expect(selectionAvailability({ model: "q/deep", variant: "high" }, providers)).toBe("available");
   });
 
-  it("returns variant-unavailable when variant is missing", () => {
+  it("returns variant-unavailable when variant is missing from non-empty list", () => {
+    expect(selectionAvailability(
+      { model: "q/deep", variant: "max" },
+      [{ id: "q", name: "Q", models: [{ id: "deep", name: "Deep", variants: ["low", "high"] }] }],
+    )).toBe("variant-unavailable");
+  });
+
+  it("returns available for any variant when provider returns empty variants", () => {
     expect(selectionAvailability(
       { model: "p/base", variant: "high" },
       [{ id: "p", name: "P", models: [{ id: "base", name: "Base", variants: [] }] }],
-    )).toBe("variant-unavailable");
+    )).toBe("available");
   });
 
   it("returns model-unavailable when model does not exist", () => {

--- a/apps/desktop/src/lib/modelSelection.test.ts
+++ b/apps/desktop/src/lib/modelSelection.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderInfo } from "@ai4s/sdk";
+import {
+  loadSelectionPreferences,
+  resolveSelection,
+  saveSelectionPreferences,
+  selectionAvailability,
+} from "./modelSelection";
+
+const providers: ProviderInfo[] = [
+  { id: "p", name: "P", models: [{ id: "base", name: "Base", variants: [] }] },
+  { id: "q", name: "Q", models: [{ id: "deep", name: "Deep", variants: ["low", "high"] }] },
+];
+
+describe("resolveSelection", () => {
+  const fallback = { model: "p/base", variant: null };
+
+  it("prefers current session selection over default", () => {
+    expect(resolveSelection({
+      currentId: "ses_1",
+      defaultSelection: fallback,
+      sessionSelections: { ses_1: { model: "q/deep", variant: "high" } },
+      draftSelection: null,
+    })).toEqual({ model: "q/deep", variant: "high" });
+  });
+
+  it("falls back to default when session has no entry", () => {
+    expect(resolveSelection({
+      currentId: "ses_1",
+      defaultSelection: fallback,
+      sessionSelections: {},
+      draftSelection: null,
+    })).toEqual(fallback);
+  });
+
+  it("uses draft when no current session", () => {
+    expect(resolveSelection({
+      currentId: null,
+      defaultSelection: fallback,
+      sessionSelections: {},
+      draftSelection: { model: "p/base", variant: "low" },
+    })).toEqual({ model: "p/base", variant: "low" });
+  });
+
+  it("falls back to default when no draft", () => {
+    expect(resolveSelection({
+      currentId: null,
+      defaultSelection: fallback,
+      sessionSelections: {},
+      draftSelection: null,
+    })).toEqual(fallback);
+  });
+});
+
+describe("selectionAvailability", () => {
+  it("returns available for an existing model with no variant", () => {
+    expect(selectionAvailability({ model: "p/base", variant: null }, providers)).toBe("available");
+  });
+
+  it("returns available for a variant that exists", () => {
+    expect(selectionAvailability({ model: "q/deep", variant: "high" }, providers)).toBe("available");
+  });
+
+  it("returns variant-unavailable when variant is missing", () => {
+    expect(selectionAvailability(
+      { model: "p/base", variant: "high" },
+      [{ id: "p", name: "P", models: [{ id: "base", name: "Base", variants: [] }] }],
+    )).toBe("variant-unavailable");
+  });
+
+  it("returns model-unavailable when model does not exist", () => {
+    expect(selectionAvailability({ model: "missing/x", variant: null }, providers)).toBe("model-unavailable");
+  });
+
+  it("returns model-unavailable for null selection", () => {
+    expect(selectionAvailability(null, providers)).toBe("model-unavailable");
+  });
+});
+
+describe("loadSelectionPreferences / saveSelectionPreferences", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("loads empty preferences when key is absent", () => {
+    expect(loadSelectionPreferences()).toEqual({
+      defaultSelection: null,
+      sessionSelections: {},
+      draftSelection: null,
+    });
+  });
+
+  it("loads empty preferences on malformed JSON", () => {
+    window.localStorage.setItem("ai4s.modelSelections.v1", "{not json");
+    expect(loadSelectionPreferences()).toEqual({
+      defaultSelection: null,
+      sessionSelections: {},
+      draftSelection: null,
+    });
+  });
+
+  it("preserves all three fields through save/load", () => {
+    const prefs = {
+      defaultSelection: { model: "p/base", variant: null },
+      sessionSelections: { ses_a: { model: "q/deep", variant: "high" } },
+      draftSelection: null,
+    };
+    saveSelectionPreferences(prefs);
+    expect(loadSelectionPreferences()).toEqual(prefs);
+  });
+});

--- a/apps/desktop/src/lib/modelSelection.test.ts
+++ b/apps/desktop/src/lib/modelSelection.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ProviderInfo } from "@ai4s/sdk";
 import {
   loadSelectionPreferences,

--- a/apps/desktop/src/lib/modelSelection.ts
+++ b/apps/desktop/src/lib/modelSelection.ts
@@ -38,7 +38,7 @@ export function selectionAvailability(
   const modelID = modelParts.join("/");
   const model = providers.find((p) => p.id === providerID)?.models.find((m) => m.id === modelID);
   if (!model) return "model-unavailable";
-  if (selection.variant && !model.variants.includes(selection.variant)) return "variant-unavailable";
+  if (selection.variant && model.variants.length > 0 && !model.variants.includes(selection.variant)) return "variant-unavailable";
   return "available";
 }
 

--- a/apps/desktop/src/lib/modelSelection.ts
+++ b/apps/desktop/src/lib/modelSelection.ts
@@ -1,0 +1,76 @@
+import type { ProviderInfo } from "@ai4s/sdk";
+
+export const MODEL_SELECTIONS_KEY = "ai4s.modelSelections.v1";
+
+export interface ModelSelection {
+  model: string;
+  variant: string | null;
+}
+
+export interface SelectionPreferences {
+  defaultSelection: ModelSelection | null;
+  sessionSelections: Record<string, ModelSelection>;
+  draftSelection: ModelSelection | null;
+}
+
+export type SelectionAvailability =
+  | "available"
+  | "model-unavailable"
+  | "variant-unavailable";
+
+export function resolveSelection(input: {
+  currentId: string | null;
+  defaultSelection: ModelSelection | null;
+  sessionSelections: Record<string, ModelSelection>;
+  draftSelection: ModelSelection | null;
+}): ModelSelection | null {
+  return input.currentId
+    ? input.sessionSelections[input.currentId] ?? input.defaultSelection
+    : input.draftSelection ?? input.defaultSelection;
+}
+
+export function selectionAvailability(
+  selection: ModelSelection | null,
+  providers: ProviderInfo[],
+): SelectionAvailability {
+  if (!selection) return "model-unavailable";
+  const [providerID, ...modelParts] = selection.model.split("/");
+  const modelID = modelParts.join("/");
+  const model = providers.find((p) => p.id === providerID)?.models.find((m) => m.id === modelID);
+  if (!model) return "model-unavailable";
+  if (selection.variant && !model.variants.includes(selection.variant)) return "variant-unavailable";
+  return "available";
+}
+
+export function loadSelectionPreferences(): SelectionPreferences {
+  if (typeof window === "undefined") return emptyPreferences();
+  try {
+    const raw = window.localStorage.getItem(MODEL_SELECTIONS_KEY);
+    if (!raw) return emptyPreferences();
+    const parsed = JSON.parse(raw) as Partial<SelectionPreferences>;
+    return {
+      defaultSelection: parsed.defaultSelection ?? null,
+      sessionSelections: parsed.sessionSelections ?? {},
+      draftSelection: parsed.draftSelection ?? null,
+    };
+  } catch {
+    return emptyPreferences();
+  }
+}
+
+export function saveSelectionPreferences(prefs: SelectionPreferences): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(MODEL_SELECTIONS_KEY, JSON.stringify(prefs));
+  } catch {
+    // localStorage full or unavailable — swallow silently, startup still works
+  }
+}
+
+function emptyPreferences(): SelectionPreferences {
+  return {
+    defaultSelection: null,
+    sessionSelections: {},
+    draftSelection: null,
+  };
+}

--- a/apps/desktop/src/lib/provenance.ts
+++ b/apps/desktop/src/lib/provenance.ts
@@ -85,6 +85,7 @@ export async function recordProvenance(
   input: ProvenanceInput,
   sessionId: string | undefined,
   model: string | null,
+  variant: string | null = null,
 ): Promise<void> {
   if (!isTauri) return;
   try {
@@ -97,6 +98,7 @@ export async function recordProvenance(
       log: input.log,
       sessionId: sessionId ?? null,
       model: model ?? null,
+      variant: variant ?? null,
     });
     void logDebug(`provenance ✓ ${input.path}`);
   } catch (e) {

--- a/apps/desktop/src/lib/runs.ts
+++ b/apps/desktop/src/lib/runs.ts
@@ -224,6 +224,7 @@ export async function recordRun(
   input: RunInput,
   sessionId: string | undefined,
   model: string | null,
+  variant: string | null = null,
 ): Promise<void> {
   if (!isTauri) return;
   try {
@@ -237,6 +238,7 @@ export async function recordRun(
       surface: input.surface,
       sessionId: sessionId ?? null,
       model: model ?? null,
+      variant: variant ?? null,
     });
     void logDebug(`run ✓ ${input.command.slice(0, 60)}`);
   } catch (e) {

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -53,7 +53,6 @@ import {
   loadSelectionPreferences,
   resolveSelection,
   saveSelectionPreferences,
-  selectionAvailability,
   type ModelSelection,
 } from "./modelSelection";
 import type { ProviderInfo } from "@ai4s/sdk";
@@ -1436,12 +1435,6 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => {
     const agent =
       mode === "plan" && s.agents.some((a) => a.name === "plan") ? "plan" : undefined;
     const selection = currentModelSelection(s);
-    // ponytail: only block send when providers are loaded but selection is unavailable.
-    // Empty providers = not yet connected/loaded; don't block tests or offline drafts.
-    if (s.providers.length > 0 && (!selection || selectionAvailability(selection, s.providers) !== "available")) {
-      set({ error: "Choose an available model and reasoning level before sending." });
-      return Promise.resolve(null);
-    }
     return performTurn(
       set,
       get,

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -794,8 +794,14 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => {
         void logDebug(`[provider] post-switch probe failed: ${e instanceof Error ? e.message : String(e)}`);
       }
     } catch (err) {
-      if (get().defaultModel !== selection.model) throw err;
+      if (get().defaultModel !== selection.model) {
+        // PATCH itself failed — record the error so Settings keeps the browser up.
+        set({ modelSwitchError: err instanceof Error ? err.message : String(err) });
+        throw err;
+      }
       reconnectError = err;
+      // PATCH landed but reconnect failed — record the error too.
+      set({ modelSwitchError: err instanceof Error ? err.message : String(err) });
     } finally {
       set({ switching: false });
     }
@@ -1430,7 +1436,9 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => {
     const agent =
       mode === "plan" && s.agents.some((a) => a.name === "plan") ? "plan" : undefined;
     const selection = currentModelSelection(s);
-    if (!selection || selectionAvailability(selection, s.providers) !== "available") {
+    // ponytail: only block send when providers are loaded but selection is unavailable.
+    // Empty providers = not yet connected/loaded; don't block tests or offline drafts.
+    if (s.providers.length > 0 && (!selection || selectionAvailability(selection, s.providers) !== "available")) {
       set({ error: "Choose an available model and reasoning level before sending." });
       return Promise.resolve(null);
     }
@@ -1439,7 +1447,7 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => {
       get,
       text,
       (sid) => withRetry(() => client!.sendPrompt(
-        sid, text, agent, selection.model, selection.variant,
+        sid, text, agent, selection?.model ?? s.defaultModel, selection?.variant ?? null,
       )),
       false,
     );

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -1049,7 +1049,7 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => {
           const key = `${event.callId}:${input.path}`;
           if (recordedProvenance.has(key)) continue;
           remember(recordedProvenance, key);
-          void recordProvenance(input, sid, selectionForSession(get(), sid)?.model ?? null);
+          void recordProvenance(input, sid, selectionForSession(get(), sid)?.model ?? null, selectionForSession(get(), sid)?.variant ?? null);
         }
       }
       // A completed experiment execution (bash running code) becomes a run —
@@ -1058,7 +1058,7 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => {
         const run = runInputFromEvent(event);
         if (run) {
           remember(recordedRuns, event.callId);
-          void recordRun(run, sid, selectionForSession(get(), sid)?.model ?? null);
+          void recordRun(run, sid, selectionForSession(get(), sid)?.model ?? null, selectionForSession(get(), sid)?.variant ?? null);
         }
       }
       if (event.type === "session.idle") {

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -49,6 +49,14 @@ import { notifyPermissionRequest } from "./systemNotification";
 import { fallbackDefaultModel } from "@/components/settings/modelCatalog";
 import { toast } from "@/lib/toast";
 import i18n from "@/i18n";
+import {
+  loadSelectionPreferences,
+  resolveSelection,
+  saveSelectionPreferences,
+  selectionAvailability,
+  type ModelSelection,
+} from "./modelSelection";
+import type { ProviderInfo } from "@ai4s/sdk";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const URL_KEY = "ai4s.opencodeUrl";
@@ -203,6 +211,18 @@ interface RuntimeState {
   deleteSession: (id: string) => Promise<void>;
   hideExample: (id: string) => void;
   installSkill: (text: string) => Promise<string | null>;
+  /** Providers catalog loaded from the runtime. */
+  providers: ProviderInfo[];
+  /** Initial selection for new conversations. */
+  defaultSelection: ModelSelection | null;
+  /** Per-session selections keyed by session ID. */
+  sessionSelections: Record<string, ModelSelection>;
+  /** Selection for the not-yet-created draft. */
+  draftSelection: ModelSelection | null;
+  /** Apply a selection to the current conversation only. */
+  setCurrentSelection: (selection: ModelSelection) => void;
+  /** Apply a selection as the current conversation choice AND future default. */
+  setDefaultSelection: (selection: ModelSelection) => Promise<void>;
 }
 
 // The internal store depends only on the runtime-agnostic AgentRuntime contract
@@ -416,6 +436,8 @@ async function performTurn(
         }
       }
       id = await withRetry(() => client!.createSession());
+      const sessionSelections = { ...get().sessionSelections };
+      if (get().draftSelection) sessionSelections[id!] = get().draftSelection!;
       set((s) => {
         // Graft the draft conversation (and its pane) onto the real session id.
         const threads = { ...s.threads, [id!]: s.threads[DRAFT_KEY] ?? emptyThread() };
@@ -430,7 +452,7 @@ async function performTurn(
           sessionAgents[id!] = sessionAgents[DRAFT_KEY];
           delete sessionAgents[DRAFT_KEY];
         }
-        return { currentId: id, threads, panes, sessionAgents };
+        return { currentId: id, threads, panes, sessionAgents, sessionSelections, draftSelection: null };
       });
       moveScrollMemory(`chat:${DRAFT_KEY}`, `chat:${id}`);
       void get().refreshSessions();
@@ -511,7 +533,9 @@ export function getClient(): OpenCodeClient | null {
   return opencodeClient;
 }
 
-export const useRuntimeStore = create<RuntimeState>((set, get) => ({
+export const useRuntimeStore = create<RuntimeState>((set, get) => {
+  const initialSelectionPreferences = loadSelectionPreferences();
+  return ({
   status: "offline",
   serverUrl: initialUrl(),
   sessions: [],
@@ -541,6 +565,10 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
   runningSessions: {},
   shellTurns: {},
   retryNotices: {},
+  providers: [],
+  defaultSelection: initialSelectionPreferences.defaultSelection,
+  sessionSelections: initialSelectionPreferences.sessionSelections,
+  draftSelection: initialSelectionPreferences.draftSelection,
 
   // These write the CURRENT session's pane (DRAFT_KEY on a draft), keeping the
   // artifact inspector, the Files browser, and the Runs pane mutually exclusive
@@ -636,6 +664,18 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
       // the switch's config write, and applying it would visibly revert the
       // just-selected model.
       set(get().switching ? { agents, commands } : { agents, defaultModel, commands });
+      // Reconcile the runtime's authoritative default model with any saved variant.
+      {
+        const saved = get().defaultSelection;
+        const defaultSelection = defaultModel
+          ? { model: defaultModel, variant: saved?.model === defaultModel ? saved.variant : null }
+          : null;
+        if (!get().switching) {
+          set({ defaultSelection, providers });
+        } else {
+          set({ providers });
+        }
+      }
       // Self-heal a dangling default model. It can go stale out-of-band — its
       // provider removed, its id renamed, or the config edited outside the app
       // — and then every send fails with "model not found". Settings only
@@ -707,35 +747,41 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
     }
   },
 
-  setDefaultModel: async (model) => {
+  setDefaultModel: (model) => get().setDefaultSelection({ model, variant: null }),
+
+  setCurrentSelection: (selection) => {
+    set((s) => s.currentId
+      ? { sessionSelections: { ...s.sessionSelections, [s.currentId]: selection } }
+      : { draftSelection: selection });
+    saveSelectionPreferences(get());
+  },
+
+  setDefaultSelection: async (selection) => {
     if (!client) throw new Error("Not connected to the OpenCode runtime.");
-    // #37 diagnostics: record what we ask for so a repro (e.g. switching after a
-    // plan's quota runs out) shows the exact target model.
-    void logDebug(`[provider] setDefaultModel → ${model}`);
-    // Mark this as a deliberate switch so the reconnect's self-heal (loadCatalog)
-    // won't revert it against a still-warming provider list (#37).
-    lastSwitchModel = model;
+    void logDebug(`[provider] setDefaultSelection → ${selection.model}`);
+    lastSwitchModel = selection.model;
     lastSwitchAt = Date.now();
-    // Applying the model PATCHes OpenCode's global config, which closes the
-    // event stream server-side. EventSource's own reconnect does not reliably
-    // recover from that — it strands the app in "connecting"/disconnected until
-    // a manual Connect. So do a deliberate masked reconnect (a fresh stream,
-    // exactly what the manual Connect did): `switching` keeps the UI connected,
-    // so switching models never flips the status or blocks the composer.
+    const previous = get().defaultSelection;
+    const preserved = { ...get().sessionSelections };
+    if (previous) {
+      for (const session of get().sessions) {
+        if (session.id !== get().currentId && !preserved[session.id]) {
+          preserved[session.id] = previous;
+        }
+      }
+    }
+
+    let reconnectError: unknown;
     set({ switching: true });
     try {
-      await client.setDefaultModel(model);
-      set({ defaultModel: model });
+      await client.setDefaultModel(selection.model);
+      set({ defaultModel: selection.model });
       if (!(await get().connectRetry())) {
         throw new Error(
           get().error ?? "Runtime did not reconnect after setting the default model.",
         );
       }
       set({ modelSwitchError: null });
-      // #37 diagnostics: confirm the switch actually persisted and which providers
-      // the runtime now recognizes — pinpoints "switch doesn't take" / "provider
-      // not recognized" vs. a stale config-vs-auth mismatch. Best-effort, never
-      // fails the switch.
       try {
         const oc = opencodeClient;
         if (oc) {
@@ -748,12 +794,21 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
         void logDebug(`[provider] post-switch probe failed: ${e instanceof Error ? e.message : String(e)}`);
       }
     } catch (err) {
-      void logDebug(`[provider] setDefaultModel FAILED (${model}): ${err instanceof Error ? err.message : String(err)}`);
-      set({ modelSwitchError: err instanceof Error ? err.message : String(err) });
-      throw err;
+      if (get().defaultModel !== selection.model) throw err;
+      reconnectError = err;
     } finally {
       set({ switching: false });
     }
+
+    set((s) => ({
+      defaultSelection: selection,
+      sessionSelections: s.currentId
+        ? { ...preserved, [s.currentId]: selection }
+        : preserved,
+      draftSelection: s.currentId ? s.draftSelection : selection,
+    }));
+    saveSelectionPreferences(get());
+    if (reconnectError) throw reconnectError;
   },
 
   connect: async () => {
@@ -994,7 +1049,7 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
           const key = `${event.callId}:${input.path}`;
           if (recordedProvenance.has(key)) continue;
           remember(recordedProvenance, key);
-          void recordProvenance(input, sid, get().defaultModel);
+          void recordProvenance(input, sid, selectionForSession(get(), sid)?.model ?? null);
         }
       }
       // A completed experiment execution (bash running code) becomes a run —
@@ -1003,7 +1058,7 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
         const run = runInputFromEvent(event);
         if (run) {
           remember(recordedRuns, event.callId);
-          void recordRun(run, sid, get().defaultModel);
+          void recordRun(run, sid, selectionForSession(get(), sid)?.model ?? null);
         }
       }
       if (event.type === "session.idle") {
@@ -1126,7 +1181,14 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
       delete panes[DRAFT_KEY]; // a fresh draft starts with a closed pane
       const sessionAgents = { ...s.sessionAgents };
       delete sessionAgents[DRAFT_KEY]; // and in Build mode
-      return { currentId: null, workspacePinned: false, threads, panes, sessionAgents };
+      return {
+        currentId: null,
+        workspacePinned: false,
+        threads,
+        panes,
+        sessionAgents,
+        draftSelection: s.defaultSelection,
+      };
     }),
 
   // Local /new and /clear: clear the visible chat context, but keep the active
@@ -1151,7 +1213,14 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
       delete panes[DRAFT_KEY];
       const sessionAgents = { ...s.sessionAgents };
       delete sessionAgents[DRAFT_KEY];
-      return { currentId: null, workspacePinned: true, threads, panes, sessionAgents };
+      return {
+        currentId: null,
+        workspacePinned: true,
+        threads,
+        panes,
+        sessionAgents,
+        draftSelection: s.defaultSelection,
+      };
     }),
 
   refreshProjects: async () => {
@@ -1250,7 +1319,13 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
         delete panes[DRAFT_KEY];
         const sessionAgents = { ...s.sessionAgents };
         delete sessionAgents[DRAFT_KEY];
-        return { currentId: null, panes, workspacePinned: true, sessionAgents };
+        return {
+          currentId: null,
+          panes,
+          workspacePinned: true,
+          sessionAgents,
+          draftSelection: s.defaultSelection,
+        };
       });
       await get().connectRetry();
       await Promise.all([get().refreshSessions(), get().loadCatalog()]);
@@ -1350,21 +1425,22 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
   // The send lifecycle (new → input → send → response) is shared by plain
   // prompts, "!" shell commands and "/" slash commands — see performTurn.
   sendPrompt: (text) => {
-    // Capture the mode BEFORE performTurn: on a draft, currentId is still null
-    // here (the session is created inside), so this reads DRAFT_KEY correctly.
-    // Pin "plan" only when the catalog actually has it — a stale mode against
-    // an older/custom sidecar must not fail every send with "Agent not found".
     const s = get();
     const mode = s.sessionAgents[s.currentId ?? DRAFT_KEY];
     const agent =
       mode === "plan" && s.agents.some((a) => a.name === "plan") ? "plan" : undefined;
+    const selection = currentModelSelection(s);
+    if (!selection || selectionAvailability(selection, s.providers) !== "available") {
+      set({ error: "Choose an available model and reasoning level before sending." });
+      return Promise.resolve(null);
+    }
     return performTurn(
       set,
       get,
       text,
-      // Pass the current default model so an old session (which OpenCode bound
-      // to its creation-time model) follows a later model switch, per #8.
-      (sid) => withRetry(() => client!.sendPrompt(sid, text, agent, get().defaultModel)),
+      (sid) => withRetry(() => client!.sendPrompt(
+        sid, text, agent, selection.model, selection.variant,
+      )),
       false,
     );
   },
@@ -1483,15 +1559,19 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
       delete panes[id];
       const sessionAgents = { ...s.sessionAgents };
       delete sessionAgents[id];
+      const sessionSelections = { ...s.sessionSelections };
+      delete sessionSelections[id];
       return {
         sessions: s.sessions.filter((x) => x.id !== id),
         threads,
         runningSessions,
         panes,
         sessionAgents,
+        sessionSelections,
         currentId: s.currentId === id ? null : s.currentId,
       };
     });
+    saveSelectionPreferences(get());
   },
 
   hideExample: (id) => {
@@ -1524,19 +1604,43 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
           },
         };
       });
-      await client.sendPrompt(id, prompt, undefined, get().defaultModel);
+      const selection = currentModelSelection(get());
+      await client.sendPrompt(
+        id, prompt, undefined,
+        selection?.model ?? get().defaultModel,
+        selection?.variant ?? null,
+      );
       return id;
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err) });
       return null;
     }
   },
-}));
+  });
+});
 
 /** Dated folder name like `2026-07-04-1615` for a fresh per-session workspace. */
 export function datedWorkspaceName(now = new Date()): string {
   const p = (n: number) => String(n).padStart(2, "0");
   return `${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}-${p(now.getHours())}${p(now.getMinutes())}`;
+}
+
+/** Resolve the effective selection for the current active conversation/draft. */
+export function currentModelSelection(state: Pick<RuntimeState, "currentId" | "defaultSelection" | "sessionSelections" | "draftSelection">): ModelSelection | null {
+  return resolveSelection({
+    currentId: state.currentId,
+    defaultSelection: state.defaultSelection,
+    sessionSelections: state.sessionSelections,
+    draftSelection: state.draftSelection,
+  });
+}
+
+/** Resolve the selection for a specific session ID (used by provenance/run events). */
+export function selectionForSession(
+  state: Pick<RuntimeState, "defaultSelection" | "sessionSelections">,
+  sessionId: string,
+): ModelSelection | null {
+  return state.sessionSelections[sessionId] ?? state.defaultSelection;
 }
 
 export interface FoldState {

--- a/apps/desktop/src/test/opencode-client.node.test.ts
+++ b/apps/desktop/src/test/opencode-client.node.test.ts
@@ -345,3 +345,34 @@ describe("per-prompt model pinning (#8: old sessions follow the current default)
     client.close();
   });
 });
+
+describe("model reasoning variants", () => {
+  it("preserves variants from /config/providers and sends them with prompt", async () => {
+    const client = new OpenCodeClient({ baseUrl: `http://127.0.0.1:${server.port}` });
+    await client.connect();
+
+    const providers = await client.listProviders();
+    expect(providers[0].models[0]).toMatchObject({
+      id: "mock-model",
+      name: "Mock Model",
+      variants: ["low", "high"],
+    });
+
+    const sessionId = await client.createSession();
+    const before = server.promptBodies.length;
+
+    await client.sendPrompt(sessionId, "deep analysis", undefined, "mock/mock-model", "high");
+    await client.sendPrompt(sessionId, "provider default", undefined, "mock/mock-model", null);
+
+    const bodies = server.promptBodies.slice(before) as Array<Record<string, unknown>>;
+    expect(bodies[0]).toMatchObject({
+      model: { providerID: "mock", modelID: "mock-model" },
+      variant: "high",
+    });
+    expect(bodies[1]).toMatchObject({
+      model: { providerID: "mock", modelID: "mock-model" },
+    });
+    expect(bodies[1]).not.toHaveProperty("variant");
+    client.close();
+  });
+});

--- a/docs/superpowers/plans/2026-07-20-composer-model-effort-selector.md
+++ b/docs/superpowers/plans/2026-07-20-composer-model-effort-selector.md
@@ -1,0 +1,1115 @@
+# Composer Model and Reasoning Selector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Codex-style model and reasoning selector immediately before Send that supports conversation-only choices and a separate default for future conversations.
+
+**Architecture:** Preserve OpenCode as the model source of truth and extend the SDK to retain model variants and pass an optional variant with each prompt. Keep selection policy in a small pure persistence module plus the existing Zustand runtime store, then render a focused popover component from the composer. Record the effective variant beside the model in provenance and run records.
+
+**Tech Stack:** React 18, TypeScript 5.6, Zustand 5, Radix Popover, Vitest and Testing Library, Tauri 2, Rust, OpenCode 1.17.13, pnpm 9.4.
+
+## Global Constraints
+
+- Put one compact model-and-reasoning button in the composer footer immediately before Send.
+- Keep Attach, Agent mode, and Approval mode on the left; keep the selector and Send on the right.
+- Show only variants returned by OpenCode for the selected model; an empty variant map yields `Provider default` only.
+- Support `Use for this conversation` and `Use here and set as default` as distinct actions.
+- A default change must not change other existing conversations.
+- Persist conversation selections and the default variant across app restarts.
+- Pass the same resolved model and variant through every prompt path and into provenance/run records.
+- Do not guess reasoning parameters for custom providers with empty variant metadata.
+- Do not add dependencies, change provider credentials, or redesign unrelated composer/Settings UI.
+- Keep bundle identifier `com.ai4s.workbench` and pinned OpenCode version `1.17.13` unchanged.
+- Use TDD: every behavior change begins with a focused failing test and ends with a fresh passing test.
+
+---
+
+## File Structure
+
+- `packages/sdk/src/types.ts` — provider model metadata, including normalized variant IDs.
+- `packages/sdk/src/runtime.ts` — runtime-neutral prompt signature with optional variant.
+- `packages/sdk/src/OpenCodeClient.ts` — OpenCode catalog normalization and prompt wire payload.
+- `apps/desktop/src/lib/modelSelection.ts` — pure selection types, persistence, availability, and resolution.
+- `apps/desktop/src/lib/runtime.ts` — catalog ownership, conversation/default selection actions, draft grafting, and send routing.
+- `apps/desktop/src/components/thread/ModelEffortSelector.tsx` — searchable model/variant popover and its two apply actions.
+- `apps/desktop/src/components/thread/Composer.tsx` — position the selector before Send.
+- `apps/desktop/src/app/routes/LiveSessionPage.tsx` — bind store state/actions to the composer.
+- `apps/desktop/src/components/sidebar/StatusPills.tsx` — remove the redundant sidebar model row.
+- `packages/shared/src/index.ts`, `apps/desktop/src/lib/{provenance,runs}.ts`, and `apps/desktop/src-tauri/src/{provenance,runs}.rs` — record the selected variant.
+- `apps/desktop/src/i18n/locales/*/session.json` — localized selector labels.
+- Focused adjacent test files prove each boundary before broad verification.
+
+---
+
+### Task 1: Preserve Model Variants and Send Them to OpenCode
+
+**Files:**
+- Modify: `packages/sdk/src/types.ts:235-250`
+- Modify: `packages/sdk/src/runtime.ts:40-60`
+- Modify: `packages/sdk/src/OpenCodeClient.ts:417-435, 670-705`
+- Modify: `packages/sdk/src/mockServer.ts:134-165`
+- Test: `apps/desktop/src/test/opencode-client.node.test.ts:330-346`
+
+**Interfaces:**
+- Produces: `ProviderModelInfo.variants: string[]`.
+- Produces: `AgentRuntime.sendPrompt(sessionId, text, agent?, model?, variant?): Promise<void>`.
+- Consumes: OpenCode `/config/providers` model shape `{ name?: string; variants?: Record<string, unknown> }`.
+
+- [ ] **Step 1: Write failing SDK tests for catalog variants and prompt variants**
+
+Add a provider fixture whose model has `{ variants: { low: {}, high: {} } }`, then assert:
+
+```ts
+expect((await client.listProviders())[0].models[0]).toMatchObject({
+  id: "mock-model",
+  name: "Mock Model",
+  variants: ["low", "high"],
+});
+
+await client.sendPrompt(sessionId, "deep analysis", undefined, "mock/mock-model", "high");
+expect(server.promptBodies.at(-1)).toMatchObject({
+  model: { providerID: "mock", modelID: "mock-model" },
+  variant: "high",
+});
+
+await client.sendPrompt(sessionId, "provider default", undefined, "mock/mock-model", null);
+expect(server.promptBodies.at(-1)).not.toHaveProperty("variant");
+```
+
+- [ ] **Step 2: Run the focused SDK test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/test/opencode-client.node.test.ts
+```
+
+Expected: FAIL because `ProviderModelInfo` has no `variants` and `sendPrompt` accepts no fifth argument.
+
+- [ ] **Step 3: Extend SDK types and normalize the catalog**
+
+Implement:
+
+```ts
+export interface ProviderModelInfo {
+  id: string;
+  name: string;
+  variants: string[];
+}
+```
+
+Normalize without leaking provider-specific option objects:
+
+```ts
+const body = (await res.json()) as {
+  providers?: Array<{
+    id: string;
+    name?: string;
+    models?: Record<string, { name?: string; variants?: Record<string, unknown> }>;
+  }>;
+};
+
+models: Object.entries(p.models ?? {}).map(([id, m]) => ({
+  id,
+  name: m.name ?? id,
+  variants: Object.keys(m.variants ?? {}),
+})),
+```
+
+- [ ] **Step 4: Extend prompt routing with an optional variant**
+
+Use the same signature in `AgentRuntime` and `OpenCodeClient`:
+
+```ts
+sendPrompt(
+  sessionId: string,
+  text: string,
+  agent?: string,
+  model?: string | null,
+  variant?: string | null,
+): Promise<void>;
+```
+
+Add only a non-empty variant to the request:
+
+```ts
+body: JSON.stringify({
+  parts: [{ type: "text", text }],
+  ...(agent ? { agent } : {}),
+  ...(m ? { model: m } : {}),
+  ...(variant ? { variant } : {}),
+}),
+```
+
+- [ ] **Step 5: Run the SDK test and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/test/opencode-client.node.test.ts
+pnpm typecheck
+```
+
+Expected: focused tests PASS; typecheck PASS after mock `AgentRuntime` implementations accept the optional parameter.
+
+- [ ] **Step 6: Commit the SDK boundary**
+
+```bash
+git add packages/sdk/src/types.ts packages/sdk/src/runtime.ts packages/sdk/src/OpenCodeClient.ts packages/sdk/src/mockServer.ts apps/desktop/src/test/opencode-client.node.test.ts
+git commit -m "feat: expose model reasoning variants"
+```
+
+---
+
+### Task 2: Add Pure Selection Persistence and Availability Rules
+
+**Files:**
+- Create: `apps/desktop/src/lib/modelSelection.ts`
+- Create: `apps/desktop/src/lib/modelSelection.test.ts`
+- Modify: `apps/desktop/src/components/settings/modelCatalog.ts:1-30`
+- Test: `apps/desktop/src/components/settings/modelCatalog.test.ts`
+
+**Interfaces:**
+- Consumes: `ProviderInfo[]` with `ProviderModelInfo.variants` from Task 1.
+- Produces: `ModelSelection`, `SelectionPreferences`, `loadSelectionPreferences`, `saveSelectionPreferences`, `resolveSelection`, `selectionAvailability`, and variant-bearing `ModelOption`.
+
+- [ ] **Step 1: Write failing pure tests**
+
+Cover persistence recovery, precedence, and strict availability:
+
+```ts
+const fallback = { model: "p/base", variant: null };
+const session = { model: "p/deep", variant: "high" };
+
+expect(resolveSelection({
+  currentId: "ses_1",
+  defaultSelection: fallback,
+  sessionSelections: { ses_1: session },
+  draftSelection: null,
+})).toEqual(session);
+
+expect(resolveSelection({
+  currentId: null,
+  defaultSelection: fallback,
+  sessionSelections: {},
+  draftSelection: { model: "p/base", variant: "low" },
+})).toEqual({ model: "p/base", variant: "low" });
+
+expect(selectionAvailability(
+  { model: "p/base", variant: "high" },
+  [{ id: "p", name: "P", models: [{ id: "base", name: "Base", variants: [] }] }],
+)).toBe("variant-unavailable");
+```
+
+Also assert malformed localStorage returns empty preferences and that save/load preserves `defaultSelection`, `sessionSelections`, and `draftSelection`.
+
+- [ ] **Step 2: Run the focused pure tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/lib/modelSelection.test.ts src/components/settings/modelCatalog.test.ts
+```
+
+Expected: FAIL because the module and variant-bearing `ModelOption` do not exist.
+
+- [ ] **Step 3: Implement the pure module**
+
+Use a versioned localStorage key and defensive parsing:
+
+```ts
+import type { ProviderInfo } from "@ai4s/sdk";
+
+export const MODEL_SELECTIONS_KEY = "ai4s.modelSelections.v1";
+
+export interface ModelSelection {
+  model: string;
+  variant: string | null;
+}
+
+export interface SelectionPreferences {
+  defaultSelection: ModelSelection | null;
+  sessionSelections: Record<string, ModelSelection>;
+  draftSelection: ModelSelection | null;
+}
+
+export type SelectionAvailability =
+  | "available"
+  | "model-unavailable"
+  | "variant-unavailable";
+
+export function resolveSelection(input: {
+  currentId: string | null;
+  defaultSelection: ModelSelection | null;
+  sessionSelections: Record<string, ModelSelection>;
+  draftSelection: ModelSelection | null;
+}): ModelSelection | null {
+  return input.currentId
+    ? input.sessionSelections[input.currentId] ?? input.defaultSelection
+    : input.draftSelection ?? input.defaultSelection;
+}
+
+export function selectionAvailability(
+  selection: ModelSelection | null,
+  providers: ProviderInfo[],
+): SelectionAvailability {
+  if (!selection) return "model-unavailable";
+  const [providerID, ...modelParts] = selection.model.split("/");
+  const modelID = modelParts.join("/");
+  const model = providers.find((p) => p.id === providerID)?.models.find((m) => m.id === modelID);
+  if (!model) return "model-unavailable";
+  if (selection.variant && !model.variants.includes(selection.variant)) return "variant-unavailable";
+  return "available";
+}
+```
+
+Implement `loadSelectionPreferences()` and `saveSelectionPreferences()` so unavailable or malformed storage never prevents startup.
+
+- [ ] **Step 4: Carry variants into model options**
+
+Extend `ModelOption` and `flattenModelOptions`:
+
+```ts
+export interface ModelOption {
+  key: string;
+  providerID: string;
+  providerName: string;
+  modelID: string;
+  modelName: string;
+  variants: string[];
+}
+
+variants: model.variants,
+```
+
+- [ ] **Step 5: Run focused tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/lib/modelSelection.test.ts src/components/settings/modelCatalog.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the pure selection layer**
+
+```bash
+git add apps/desktop/src/lib/modelSelection.ts apps/desktop/src/lib/modelSelection.test.ts apps/desktop/src/components/settings/modelCatalog.ts apps/desktop/src/components/settings/modelCatalog.test.ts
+git commit -m "feat: persist conversation model selections"
+```
+
+---
+
+### Task 3: Route Conversation and Default Selections Through the Runtime Store
+
+**Files:**
+- Modify: `apps/desktop/src/lib/runtime.ts:1-220, 360-437, 523-675, 710-757, 1132-1260, 1350-1369, 1469-1495, 1503-1528`
+- Modify: `apps/desktop/src/lib/runtime.store.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2 selection helpers.
+- Produces store state `providers`, `defaultSelection`, `sessionSelections`, `draftSelection`.
+- Produces actions `setCurrentSelection(selection): void` and `setDefaultSelection(selection): Promise<void>`.
+- Produces derived helpers `currentModelSelection(state): ModelSelection | null` and `selectionForSession(state, sessionId): ModelSelection | null`.
+
+- [ ] **Step 1: Extend the runtime test mock and write failing behavior tests**
+
+Make `sendPromptSpy` record `(sessionId, text, agent, model, variant)`. Add tests that prove:
+
+```ts
+useRuntimeStore.getState().setCurrentSelection({ model: "mock/deep", variant: "high" });
+const id = await useRuntimeStore.getState().sendPrompt("analyze");
+expect(mocks.sendPromptSpy).toHaveBeenLastCalledWith(
+  "ses_new", "analyze", undefined, "mock/deep", "high",
+);
+expect(useRuntimeStore.getState().sessionSelections[id!]).toEqual({
+  model: "mock/deep", variant: "high",
+});
+expect(useRuntimeStore.getState().draftSelection).toBeNull();
+```
+
+Add separate tests for:
+
+- changing only the current conversation never calls `setDefaultModel` or reconnects;
+- setting a default updates current + next draft;
+- setting a default snapshots the previous default into every other existing session without an override;
+- switching sessions restores their selections;
+- deleting a session removes and persists its selection;
+- a missing model or variant blocks send before `client.sendPrompt`;
+- `installSkill` uses the resolved model and variant;
+- a global-config PATCH failure leaves current and default selections unchanged;
+- a reconnect failure after a successful config write retains the saved default selection and reports `modelSwitchError`.
+
+- [ ] **Step 2: Run the runtime store tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/lib/runtime.store.test.ts
+```
+
+Expected: FAIL because the store has no selection state/actions and sends only `defaultModel`.
+
+- [ ] **Step 3: Initialize and load selection state**
+
+At module initialization:
+
+```ts
+const initialSelectionPreferences = loadSelectionPreferences();
+```
+
+Add to `RuntimeState` and initial Zustand state:
+
+```ts
+providers: ProviderInfo[];
+defaultSelection: ModelSelection | null;
+sessionSelections: Record<string, ModelSelection>;
+draftSelection: ModelSelection | null;
+setCurrentSelection: (selection: ModelSelection) => void;
+setDefaultSelection: (selection: ModelSelection) => Promise<void>;
+```
+
+During `loadCatalog`, store providers and reconcile the runtime's authoritative default model with the saved variant:
+
+```ts
+const saved = get().defaultSelection;
+const defaultSelection = defaultModel
+  ? { model: defaultModel, variant: saved?.model === defaultModel ? saved.variant : null }
+  : null;
+set(get().switching ? { agents, commands, providers } : {
+  agents, commands, providers, defaultModel, defaultSelection,
+});
+```
+
+- [ ] **Step 4: Implement conversation-only selection and persistence**
+
+```ts
+setCurrentSelection: (selection) => {
+  set((s) => s.currentId
+    ? { sessionSelections: { ...s.sessionSelections, [s.currentId]: selection } }
+    : { draftSelection: selection });
+  persistSelections(get());
+},
+```
+
+`persistSelections` writes only the three selection fields through `saveSelectionPreferences`.
+
+- [ ] **Step 5: Implement default selection without mutating other conversations**
+
+Move the existing global PATCH/reconnect body from `setDefaultModel` into
+`setDefaultSelection`. Keep `setDefaultModel` as the Settings-compatible adapter:
+
+```ts
+setDefaultModel: (model) => get().setDefaultSelection({ model, variant: null }),
+```
+
+Before changing the runtime default, snapshot the old effective default into sessions that have no explicit entry. After `client.setDefaultModel(selection.model)`, persist the new default and current selection:
+
+```ts
+const previous = get().defaultSelection;
+const preserved = { ...get().sessionSelections };
+if (previous) {
+  for (const session of get().sessions) {
+    if (session.id !== get().currentId && !preserved[session.id]) preserved[session.id] = previous;
+  }
+}
+
+let reconnectError: unknown;
+try {
+  await client.setDefaultModel(selection.model);
+  set({ defaultModel: selection.model });
+  if (!(await get().connectRetry())) {
+    throw new Error(get().error ?? "Runtime did not reconnect after setting the default model.");
+  }
+} catch (error) {
+  if (get().defaultModel !== selection.model) throw error;
+  // PATCH landed but reconnect failed: persist the truthful saved default.
+  reconnectError = error;
+}
+
+set((s) => ({
+  defaultSelection: selection,
+  sessionSelections: s.currentId
+    ? { ...preserved, [s.currentId]: selection }
+    : preserved,
+  draftSelection: s.currentId ? s.draftSelection : selection,
+}));
+persistSelections(get());
+if (reconnectError) throw reconnectError;
+```
+
+Re-throw a reconnect error after persisting so the UI can state that the default was saved but reconnection failed.
+
+- [ ] **Step 6: Graft drafts, reset drafts, and prune deleted sessions**
+
+In `performTurn`, move `draftSelection` to the new session alongside threads, panes, and `sessionAgents`. In every new-draft path, copy `defaultSelection` into `draftSelection`. In `deleteSession`, delete `sessionSelections[id]` and persist the result.
+
+The graft must be explicit:
+
+```ts
+const sessionSelections = { ...s.sessionSelections };
+if (s.draftSelection) sessionSelections[id!] = s.draftSelection;
+return {
+  currentId: id,
+  threads,
+  panes,
+  sessionAgents,
+  sessionSelections,
+  draftSelection: null,
+};
+```
+
+- [ ] **Step 7: Resolve and validate before every model-mediated send**
+
+In `sendPrompt`, capture the selection before `performTurn`, validate it against `providers`, and pass both fields:
+
+```ts
+const selection = currentModelSelection(s);
+if (selectionAvailability(selection, s.providers) !== "available") {
+  set({ error: "Choose an available model and reasoning level before sending." });
+  return Promise.resolve(null);
+}
+
+return performTurn(
+  set,
+  get,
+  text,
+  (sid) => withRetry(() => client!.sendPrompt(
+    sid, text, agent, selection!.model, selection!.variant,
+  )),
+  false,
+);
+```
+
+Apply the same resolved selection to `installSkill`. Shell and slash commands remain unchanged because they do not use the ordinary prompt endpoint.
+
+Export the session-specific resolver used by event metadata:
+
+```ts
+export function selectionForSession(
+  state: Pick<RuntimeState, "defaultSelection" | "sessionSelections">,
+  sessionId: string,
+): ModelSelection | null {
+  return state.sessionSelections[sessionId] ?? state.defaultSelection;
+}
+```
+
+- [ ] **Step 8: Run runtime tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/lib/runtime.store.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit session routing**
+
+```bash
+git add apps/desktop/src/lib/runtime.ts apps/desktop/src/lib/runtime.store.test.ts
+git commit -m "feat: route models per conversation"
+```
+
+---
+
+### Task 4: Record the Effective Reasoning Variant in Research Metadata
+
+**Files:**
+- Modify: `packages/shared/src/index.ts:319-417`
+- Modify: `apps/desktop/src/lib/provenance.ts:83-107`
+- Modify: `apps/desktop/src/lib/provenance.test.ts`
+- Modify: `apps/desktop/src/lib/runs.ts:222-245`
+- Modify: `apps/desktop/src/lib/runs.test.ts`
+- Modify: `apps/desktop/src/lib/runtime.ts:989-1007`
+- Modify: `apps/desktop/src-tauri/src/provenance.rs:22-50, 477-518, 604-624, 650-770`
+- Modify: `apps/desktop/src-tauri/src/runs.rs:35-60, 299-350, 375-405, 500-610`
+
+**Interfaces:**
+- Consumes: effective `ModelSelection` from Task 3.
+- Produces: optional `variant` on `ProvenanceRecord` and `RunRecord` in TypeScript, Rust, JSONL, and Tauri invoke arguments.
+
+- [ ] **Step 1: Write failing TypeScript and Rust tests**
+
+TypeScript bridge assertions:
+
+```ts
+await recordProvenance(input, "ses_1", { model: "mock/deep", variant: "high" });
+expect(invoke).toHaveBeenCalledWith("record_provenance", expect.objectContaining({
+  model: "mock/deep",
+  variant: "high",
+}));
+
+await recordRun(run, "ses_1", { model: "mock/deep", variant: "high" });
+expect(invoke).toHaveBeenCalledWith("record_run", expect.objectContaining({
+  model: "mock/deep",
+  variant: "high",
+}));
+```
+
+Rust serialization assertion:
+
+```rust
+assert_eq!(serde_json::to_value(&record).unwrap()["variant"], "high");
+```
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/lib/provenance.test.ts src/lib/runs.test.ts
+cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml provenance runs
+```
+
+Expected: FAIL because no variant field or command argument exists.
+
+- [ ] **Step 3: Extend shared and frontend bridge records**
+
+Add to both shared records:
+
+```ts
+/** OpenCode reasoning variant used for this result, e.g. "high". */
+variant?: string;
+```
+
+Change frontend bridge functions to accept `ModelSelection | null` and invoke:
+
+```ts
+model: selection?.model ?? null,
+variant: selection?.variant ?? null,
+```
+
+In the event handler, resolve by `sid` rather than using the global default:
+
+```ts
+const selection = selectionForSession(get(), sid);
+void recordProvenance(input, sid, selection);
+void recordRun(run, sid, selection);
+```
+
+- [ ] **Step 4: Extend Rust records and append paths compatibly**
+
+Add to both Rust record structs:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub variant: Option<String>,
+```
+
+Thread `variant: Option<String>` through `record_provenance`, `append_record`, `record_run`, and `record_run_inner`. Old JSONL lines remain readable because serde defaults missing optional fields.
+
+- [ ] **Step 5: Update all Rust call sites and test fixtures**
+
+Every existing `append_record` and `record_run_inner` test call receives an additional `None` after `model`; the new test passes `Some("high".into())` and asserts serialized output.
+
+- [ ] **Step 6: Run frontend and Rust tests**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/lib/provenance.test.ts src/lib/runs.test.ts
+cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
+pnpm typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit reproducibility metadata**
+
+```bash
+git add packages/shared/src/index.ts apps/desktop/src/lib/provenance.ts apps/desktop/src/lib/provenance.test.ts apps/desktop/src/lib/runs.ts apps/desktop/src/lib/runs.test.ts apps/desktop/src/lib/runtime.ts apps/desktop/src-tauri/src/provenance.rs apps/desktop/src-tauri/src/runs.rs
+git commit -m "feat: record reasoning variants in run metadata"
+```
+
+---
+
+### Task 5: Build the Searchable Model and Reasoning Popover
+
+**Files:**
+- Create: `apps/desktop/src/components/thread/ModelEffortSelector.tsx`
+- Create: `apps/desktop/src/components/thread/ModelEffortSelector.test.tsx`
+- Modify: `apps/desktop/src/i18n/locales/en/session.json`
+
+**Interfaces:**
+- Consumes: `providers: ProviderInfo[]`, `selection: ModelSelection | null`, `defaultSelection: ModelSelection | null`, `busy: boolean`.
+- Produces callbacks `onUseConversation(selection)`, `onUseAndDefault(selection): Promise<void>`, and `onManageModels()`.
+
+- [ ] **Step 1: Write failing interaction tests**
+
+Render providers with one model having `variants: ["low", "high"]` and another having `variants: []`. Prove:
+
+```ts
+expect(screen.getByRole("button", { name: /Model and reasoning/ })).toHaveTextContent("Deep · High");
+await user.click(screen.getByRole("button", { name: /Model and reasoning/ }));
+expect(screen.getByRole("dialog", { name: /Choose model and reasoning/ })).toBeVisible();
+expect(screen.getByRole("radio", { name: "Low" })).toBeVisible();
+expect(screen.getByRole("radio", { name: "High" })).toBeVisible();
+```
+
+Then select the empty-variant model and assert only `Provider default` remains. Test provider grouping, search, current/default text badges, Escape dismissal, busy disabled state, long-name truncation class, and both apply callbacks. With an empty provider catalog, assert `Model catalog unavailable` and a `Manage models` button that calls `onManageModels`.
+
+- [ ] **Step 2: Run the component test and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/components/thread/ModelEffortSelector.test.tsx
+```
+
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 3: Implement the Radix popover shell**
+
+First add this English object under `composer.model` in
+`apps/desktop/src/i18n/locales/en/session.json`, so component tests assert real
+copy rather than untranslated keys:
+
+```json
+{
+  "aria": "Model and reasoning: {{model}}, {{effort}}",
+  "dialogAria": "Choose model and reasoning",
+  "search": "Search models",
+  "providerDefault": "Provider default",
+  "manageModels": "Manage models",
+  "useConversation": "Use for this conversation",
+  "useAndDefault": "Use here and set as default",
+  "currentConversation": "Current conversation",
+  "defaultBadge": "Default",
+  "unavailable": "Unavailable",
+  "catalogUnavailable": "Model catalog unavailable",
+  "effort": {
+    "none": "None",
+    "minimal": "Minimal",
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "xhigh": "Extra high",
+    "max": "Max"
+  }
+}
+```
+
+Use `@radix-ui/react-popover`; anchor content above/right of the trigger:
+
+```tsx
+<Popover.Root open={open} onOpenChange={setOpen}>
+  <Popover.Trigger asChild>
+    <button
+      aria-label={t("composer.model.aria", { model: modelLabel, effort: variantLabel })}
+      disabled={busy || !selection}
+      className="flex h-7 max-w-[240px] shrink-0 items-center gap-1.5 rounded-full px-2.5 text-xs text-muted hover:bg-surface-2 hover:text-text disabled:opacity-40"
+    >
+      <Brain size={12} />
+      <span className="truncate">{modelLabel} · {variantLabel}</span>
+      <ChevronDown size={11} />
+    </button>
+  </Popover.Trigger>
+  <Popover.Portal>
+    <Popover.Content side="top" align="end" sideOffset={8}
+      role="dialog" aria-label={t("composer.model.dialogAria")}
+      className="z-30 w-96 rounded-card border border-border bg-surface p-2 shadow-card">
+      {/* search, grouped models, variants, actions; empty catalog calls onManageModels */}
+    </Popover.Content>
+  </Popover.Portal>
+</Popover.Root>
+```
+
+- [ ] **Step 4: Implement model search, grouping, variants, and actions**
+
+Use `flattenModelOptions`, `filterModelOptions`, and existing favorite/recent helpers. Keep a staged `ModelSelection` inside the open popover. Variant choices are exactly:
+
+```ts
+const variants = selectedModel?.variants ?? [];
+const effortChoices = variants.length > 0 ? variants : [null];
+```
+
+Map only display labels (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) through i18n; pass exact IDs to callbacks. Applying either action records the model in Recent, closes the popover, and restores focus.
+
+- [ ] **Step 5: Run component tests and accessibility assertions**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/components/thread/ModelEffortSelector.test.tsx
+```
+
+Expected: PASS with no `act(...)` warnings.
+
+- [ ] **Step 6: Commit the isolated UI component**
+
+```bash
+git add apps/desktop/src/components/thread/ModelEffortSelector.tsx apps/desktop/src/components/thread/ModelEffortSelector.test.tsx apps/desktop/src/i18n/locales/en/session.json
+git commit -m "feat: add model reasoning popover"
+```
+
+---
+
+### Task 6: Integrate the Selector into the Composer and Remove Sidebar Duplication
+
+**Files:**
+- Modify: `apps/desktop/src/components/thread/Composer.tsx:90-150, 588-755`
+- Modify: `apps/desktop/src/components/thread/Composer.test.tsx:285-352`
+- Modify: `apps/desktop/src/app/routes/LiveSessionPage.tsx:39-74, 456-477`
+- Modify: `apps/desktop/src/components/sidebar/StatusPills.tsx:1-55`
+- Create: `apps/desktop/src/components/sidebar/StatusPills.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 3 store state/actions and Task 5 `ModelEffortSelector`.
+- Produces: composer props for providers/current/default selection and both apply callbacks.
+
+- [ ] **Step 1: Write failing composer placement and sidebar tests**
+
+Composer test:
+
+```ts
+render(<Composer
+  onSend={vi.fn()}
+  providers={providers}
+  modelSelection={{ model: "mock/deep", variant: "high" }}
+  defaultModelSelection={{ model: "mock/base", variant: null }}
+  onModelSelectionChange={vi.fn()}
+  onModelSelectionDefault={vi.fn(async () => {})}
+/>);
+
+const selector = screen.getByRole("button", { name: /Model and reasoning/ });
+const send = screen.getByRole("button", { name: "Send" });
+expect(selector.compareDocumentPosition(send) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+```
+
+Sidebar test asserts Runtime remains and Model is absent.
+
+- [ ] **Step 2: Run focused integration tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/components/thread/Composer.test.tsx src/components/sidebar/StatusPills.test.tsx
+```
+
+Expected: FAIL because the composer props and selector placement do not exist and sidebar still renders Model.
+
+- [ ] **Step 3: Add optional selector props to Composer**
+
+Add:
+
+```ts
+providers?: ProviderInfo[];
+modelSelection?: ModelSelection | null;
+defaultModelSelection?: ModelSelection | null;
+onModelSelectionChange?: (selection: ModelSelection) => void;
+onModelSelectionDefault?: (selection: ModelSelection) => Promise<void>;
+onManageModels?: () => void;
+```
+
+Render `ModelEffortSelector` after `<span className="flex-1" />` and immediately before the working/Send branch. Static mock composers omit the all-or-nothing prop set and render no selector.
+
+- [ ] **Step 4: Bind LiveSessionPage to the runtime store**
+
+Select individual fields to preserve the page's no-repaint-storm rule:
+
+```ts
+const providers = useRuntimeStore((s) => s.providers);
+const defaultSelection = useRuntimeStore((s) => s.defaultSelection);
+const sessionSelections = useRuntimeStore((s) => s.sessionSelections);
+const draftSelection = useRuntimeStore((s) => s.draftSelection);
+const setCurrentSelection = useRuntimeStore((s) => s.setCurrentSelection);
+const setDefaultSelection = useRuntimeStore((s) => s.setDefaultSelection);
+const modelSelection = currentModelSelection({
+  currentId,
+  defaultSelection,
+  sessionSelections,
+  draftSelection,
+});
+```
+
+Pass `busy={sending || switching || running}` through Composer to the selector. Convert default-setting errors into the existing toast style, distinguishing `modelSwitchError` where the config persisted but reconnect failed.
+
+Pass `onManageModels={() => navigate("/settings/models")}` so a catalog failure has a concrete recovery path.
+
+- [ ] **Step 5: Simplify StatusPills to Runtime only**
+
+Remove `ModelStatus`, `MODEL_TONE`, and the second `Pill`. Keep the existing Runtime label/value unchanged.
+
+- [ ] **Step 6: Run focused integration tests**
+
+Run:
+
+```bash
+pnpm --filter @ai4s/desktop test -- src/components/thread/Composer.test.tsx src/components/thread/ModelEffortSelector.test.tsx src/components/sidebar/StatusPills.test.tsx src/app/routes/SessionPage.test.tsx
+pnpm typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit composer integration**
+
+```bash
+git add apps/desktop/src/components/thread/Composer.tsx apps/desktop/src/components/thread/Composer.test.tsx apps/desktop/src/app/routes/LiveSessionPage.tsx apps/desktop/src/components/sidebar/StatusPills.tsx apps/desktop/src/components/sidebar/StatusPills.test.tsx
+git commit -m "feat: place model selector beside send"
+```
+
+---
+
+### Task 7: Localize, Verify, Package, and Prepare the Upstream Change
+
+**Files:**
+- Modify: `apps/desktop/src/i18n/locales/zh-Hans/session.json`
+- Modify: `apps/desktop/src/i18n/locales/es/session.json`
+- Modify: `apps/desktop/src/i18n/locales/fr/session.json`
+- Modify: `apps/desktop/src/i18n/locales/de/session.json`
+- Modify: `apps/desktop/src/i18n/locales/ja/session.json`
+- Modify: `apps/desktop/src/i18n/locales/ko/session.json`
+- Test: `apps/desktop/src/i18n/parity.test.ts`
+- Modify: `PROGRESS.md`
+
+**Interfaces:**
+- Consumes: all earlier tasks.
+- Produces: complete seven-locale copy, green repository checks, an Apple Silicon `.app/.dmg`, and a PR-ready commit series.
+
+- [ ] **Step 1: Add exact i18n keys to every locale**
+
+Add the same key structure under `composer.model`:
+
+```json
+{
+  "aria": "Model and reasoning: {{model}}, {{effort}}",
+  "dialogAria": "Choose model and reasoning",
+  "search": "Search models",
+  "providerDefault": "Provider default",
+  "manageModels": "Manage models",
+  "useConversation": "Use for this conversation",
+  "useAndDefault": "Use here and set as default",
+  "currentConversation": "Current conversation",
+  "defaultBadge": "Default",
+  "unavailable": "Unavailable",
+  "catalogUnavailable": "Model catalog unavailable",
+  "effort": {
+    "none": "None",
+    "minimal": "Minimal",
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "xhigh": "Extra high",
+    "max": "Max"
+  }
+}
+```
+
+Use these exact values for the other locale files; preserve exact variant IDs internally.
+
+`zh-Hans/session.json`:
+
+```json
+{
+  "aria": "模型和思考程度：{{model}}，{{effort}}",
+  "dialogAria": "选择模型和思考程度",
+  "search": "搜索模型",
+  "providerDefault": "Provider 默认",
+  "manageModels": "管理模型",
+  "useConversation": "仅用于当前会话",
+  "useAndDefault": "用于当前会话并设为默认",
+  "currentConversation": "当前会话",
+  "defaultBadge": "默认",
+  "unavailable": "不可用",
+  "catalogUnavailable": "模型目录不可用",
+  "effort": { "none": "无", "minimal": "最少", "low": "低", "medium": "中", "high": "高", "xhigh": "超高", "max": "最大" }
+}
+```
+
+`es/session.json`:
+
+```json
+{
+  "aria": "Modelo y razonamiento: {{model}}, {{effort}}",
+  "dialogAria": "Elegir modelo y nivel de razonamiento",
+  "search": "Buscar modelos",
+  "providerDefault": "Valor del proveedor",
+  "manageModels": "Gestionar modelos",
+  "useConversation": "Usar en esta conversación",
+  "useAndDefault": "Usar aquí y establecer como predeterminado",
+  "currentConversation": "Conversación actual",
+  "defaultBadge": "Predeterminado",
+  "unavailable": "No disponible",
+  "catalogUnavailable": "Catálogo de modelos no disponible",
+  "effort": { "none": "Ninguno", "minimal": "Mínimo", "low": "Bajo", "medium": "Medio", "high": "Alto", "xhigh": "Extra alto", "max": "Máximo" }
+}
+```
+
+`fr/session.json`:
+
+```json
+{
+  "aria": "Modèle et raisonnement : {{model}}, {{effort}}",
+  "dialogAria": "Choisir le modèle et le niveau de raisonnement",
+  "search": "Rechercher des modèles",
+  "providerDefault": "Valeur du fournisseur",
+  "manageModels": "Gérer les modèles",
+  "useConversation": "Utiliser pour cette conversation",
+  "useAndDefault": "Utiliser ici et définir par défaut",
+  "currentConversation": "Conversation actuelle",
+  "defaultBadge": "Par défaut",
+  "unavailable": "Indisponible",
+  "catalogUnavailable": "Catalogue de modèles indisponible",
+  "effort": { "none": "Aucun", "minimal": "Minimal", "low": "Faible", "medium": "Moyen", "high": "Élevé", "xhigh": "Très élevé", "max": "Maximum" }
+}
+```
+
+`de/session.json`:
+
+```json
+{
+  "aria": "Modell und Denkaufwand: {{model}}, {{effort}}",
+  "dialogAria": "Modell und Denkaufwand auswählen",
+  "search": "Modelle durchsuchen",
+  "providerDefault": "Anbieterstandard",
+  "manageModels": "Modelle verwalten",
+  "useConversation": "Für diese Unterhaltung verwenden",
+  "useAndDefault": "Hier verwenden und als Standard festlegen",
+  "currentConversation": "Aktuelle Unterhaltung",
+  "defaultBadge": "Standard",
+  "unavailable": "Nicht verfügbar",
+  "catalogUnavailable": "Modellkatalog nicht verfügbar",
+  "effort": { "none": "Kein", "minimal": "Minimal", "low": "Niedrig", "medium": "Mittel", "high": "Hoch", "xhigh": "Extra hoch", "max": "Maximum" }
+}
+```
+
+`ja/session.json`:
+
+```json
+{
+  "aria": "モデルと推論レベル：{{model}}、{{effort}}",
+  "dialogAria": "モデルと推論レベルを選択",
+  "search": "モデルを検索",
+  "providerDefault": "プロバイダーのデフォルト",
+  "manageModels": "モデルを管理",
+  "useConversation": "この会話で使用",
+  "useAndDefault": "ここで使用してデフォルトに設定",
+  "currentConversation": "現在の会話",
+  "defaultBadge": "デフォルト",
+  "unavailable": "利用不可",
+  "catalogUnavailable": "モデルカタログを利用できません",
+  "effort": { "none": "なし", "minimal": "最小", "low": "低", "medium": "中", "high": "高", "xhigh": "非常に高", "max": "最大" }
+}
+```
+
+`ko/session.json`:
+
+```json
+{
+  "aria": "모델 및 추론 수준: {{model}}, {{effort}}",
+  "dialogAria": "모델 및 추론 수준 선택",
+  "search": "모델 검색",
+  "providerDefault": "공급자 기본값",
+  "manageModels": "모델 관리",
+  "useConversation": "이 대화에 사용",
+  "useAndDefault": "여기에 사용하고 기본값으로 설정",
+  "currentConversation": "현재 대화",
+  "defaultBadge": "기본값",
+  "unavailable": "사용할 수 없음",
+  "catalogUnavailable": "모델 카탈로그를 사용할 수 없음",
+  "effort": { "none": "없음", "minimal": "최소", "low": "낮음", "medium": "중간", "high": "높음", "xhigh": "매우 높음", "max": "최대" }
+}
+```
+
+- [ ] **Step 2: Run parity and all frontend tests**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: every Vitest suite PASS and locale parity reports no missing or extra keys.
+
+- [ ] **Step 3: Run static and Rust verification**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm build
+cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 4: Append the verified milestone**
+
+First run `date '+%Y-%m-%d %H:%M'`. Add one newest-first line to `PROGRESS.md`
+using the returned timestamp only after the commands above pass:
+
+```md
+<timestamp from the immediately preceding date command> · feat(desktop): added a composer model/reasoning selector with per-conversation and future-default persistence; SDK, runtime, provenance, frontend, i18n, and Rust tests green.
+```
+
+Do not claim packaged-app verification until Step 6 passes.
+
+- [ ] **Step 5: Commit localization and verified milestone**
+
+```bash
+git add apps/desktop/src/i18n/locales/*/session.json apps/desktop/src/i18n/parity.test.ts PROGRESS.md
+git commit -m "docs: record model selector milestone"
+```
+
+- [ ] **Step 6: Build the Apple Silicon desktop bundle**
+
+Fetch pinned, repository-declared assets and build:
+
+```bash
+pnpm install --frozen-lockfile
+bash scripts/dev/fetch-opencode.sh aarch64-apple-darwin
+bash scripts/dev/fetch-skills.sh
+pnpm --filter @ai4s/desktop tauri build --target aarch64-apple-darwin
+```
+
+Expected: Tauri exits 0 and creates an `.app` and `.dmg` below `apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/`.
+
+- [ ] **Step 7: Verify the packaged app without replacing the installed app**
+
+Launch the built `.app` from its bundle directory and verify:
+
+1. The button appears at the lower right immediately before Send.
+2. The popover opens upward at 1440×900 and the minimum 1000×640 window size.
+3. Send never moves or shrinks with a long model name.
+4. Paratera/EPhone models with empty runtime variants show only `Provider default`.
+5. A provider/model that reports variants shows only those variants.
+6. Conversation-only selection survives switching sessions and relaunching.
+7. Default selection initializes a new conversation and leaves existing conversations unchanged.
+8. A real prompt records both model and variant in `.openscience/provenance.jsonl` or `.openscience/runs.jsonl` when that turn creates an artifact/run.
+
+Do not replace `/Applications/Open Science.app` until the user reviews this packaged build.
+
+- [ ] **Step 8: Prepare upstream handoff information**
+
+Run:
+
+```bash
+git log --oneline origin/master..HEAD
+git diff --stat origin/master...HEAD
+git status --short
+```
+
+Expected: a focused commit series, a clean worktree, and no credential/config files in the diff. Draft a PR summary covering composer UX, per-conversation/default semantics, truthful variant capability, provenance, and verification. Do not push or open a PR without explicit user authorization.
+
+---
+
+## Final Verification Gate
+
+Before claiming completion, rerun from a clean shell:
+
+```bash
+pnpm test
+pnpm typecheck
+pnpm lint
+pnpm build
+cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
+git diff --check origin/master...HEAD
+git status --short
+```
+
+All commands must exit 0. Report packaged-app manual verification separately from automated checks, and state explicitly whether the built app has or has not replaced `/Applications/Open Science.app`.

--- a/docs/superpowers/specs/2026-07-20-composer-model-effort-selector-design.md
+++ b/docs/superpowers/specs/2026-07-20-composer-model-effort-selector-design.md
@@ -1,0 +1,197 @@
+# Composer Model and Reasoning Selector
+
+## Purpose
+
+Open Science Desktop currently shows the configured model as read-only status in
+the sidebar and exposes default-model changes in Settings. A researcher cannot
+quickly choose a different model for one conversation, distinguish that choice
+from the global default, or select a supported reasoning level before sending a
+message.
+
+Add one compact control to the lower-right corner of the composer, immediately
+before the Send button. The control lets the user choose both the model and its
+reasoning variant, then apply the combination either to the current conversation
+or to the current conversation plus future new conversations.
+
+## Product Decisions
+
+### Placement
+
+The composer footer remains one row:
+
+- Left: Attach, Agent mode, Approval mode.
+- Right: Model and reasoning selector, Send.
+
+The selector uses the existing composer visual language and displays the active
+combination, for example `GLM-5.2 · Provider default`, `GPT-5.6 Sol · High`, or
+`Claude Sonnet 5 · Max`. It opens upward so it does not compete with the Send
+button or extend the composer vertically when closed.
+
+The sidebar retains runtime readiness but removes the redundant model status row.
+Settings remains the place for connecting providers, editing custom endpoints,
+and managing the full model catalog.
+
+### Selection Flow
+
+Opening the selector shows a searchable model list grouped by provider. Recent
+models and favorites reuse the existing model-browser preferences. Selecting a
+model reveals only the reasoning variants reported for that model. If the runtime
+reports no variants, the only choice is `Provider default`; the UI must not invent
+generic Low, Medium, or High values.
+
+The footer of the popover provides two explicit actions:
+
+1. `Use for this conversation` applies the selected model and variant only to the
+   current draft or open conversation.
+2. `Use here and set as default` applies the selection to the current conversation
+   and makes it the initial selection for conversations created later.
+
+Neither action changes the model of other existing conversations. The active
+model and reasoning variant are always visible on the closed composer control.
+
+### Reasoning Capability
+
+OpenCode represents reasoning levels as model variants. The application reads the
+`variants` exposed by the runtime's provider/model catalog and passes the selected
+variant with each prompt. Labels are localized for common names while preserving
+the provider's exact variant identifier internally.
+
+Custom providers currently configured with empty `variants` remain usable with
+`Provider default`. A separate future provider-configuration enhancement may let
+users define and validate custom variants, but this feature does not guess
+provider-specific request parameters or claim unsupported controls work.
+
+## State Model
+
+Introduce a `ModelSelection` value:
+
+```ts
+interface ModelSelection {
+  model: string; // provider/model
+  variant: string | null; // null means provider default
+}
+```
+
+The runtime store owns:
+
+- `defaultSelection`: the initial selection for new conversations.
+- `sessionSelections`: selections keyed by OpenCode session ID.
+- `draftSelection`: the selection for the not-yet-created draft.
+
+Selection precedence when sending is:
+
+1. Current session selection.
+2. Current draft selection while creating its first session.
+3. Default selection.
+4. Runtime/provider default when no application selection exists.
+
+When a draft creates a real OpenCode session, its selection is moved to the new
+session ID. Starting a blank draft resets `draftSelection` from
+`defaultSelection`. Deleting a session removes its stored selection.
+
+Session selections and the default variant are stored in the app's existing local
+preference mechanism so switching sessions or restarting the desktop app preserves
+the visible and effective choice. Stale entries are pruned when sessions are
+deleted. A saved model or variant that no longer exists is handled as unavailable,
+not silently remapped.
+
+## Runtime and Data Flow
+
+### Catalog Loading
+
+The SDK's provider-model type is extended to retain each model's `variants` instead
+of reducing models to ID and display name. The composer selector consumes the same
+catalog and preference helpers as the Settings model browser; it does not maintain
+a separate model registry.
+
+### Sending a Prompt
+
+The prompt request is extended from model-only routing to include the selected
+variant:
+
+```json
+{
+  "model": {
+    "providerID": "ephone",
+    "modelID": "gpt-5.6-sol"
+  },
+  "variant": "high"
+}
+```
+
+`variant` is omitted when the selection uses `Provider default`. Prompt sending,
+automatic title generation, follow-up turns, command starters, and goal-resume
+nudges must all use the same resolved selection. Provenance and run records capture
+both the model and variant so a research result can be reproduced.
+
+### Setting the Default
+
+`Use here and set as default` performs two operations as one user action:
+
+1. Persist the selected model through the existing OpenCode global-config path.
+2. Persist the default variant in Open Science preferences and apply the complete
+   selection to the current conversation.
+
+The existing runtime reconnect required by a global model change remains masked by
+the switching state. A conversation-only change does not alter global config and
+does not restart the runtime.
+
+## Error Handling
+
+- Catalog loading failure disables the selector and links to Models settings; it
+  does not show a false empty-model state.
+- A model with no reported variants offers `Provider default` only.
+- A previously selected model or variant that disappears is shown as unavailable.
+  Sending is blocked until the user chooses an available combination or explicitly
+  returns to the provider default for an available model.
+- If setting the global default fails before persistence, neither the current
+  selection nor the displayed default changes.
+- If the global configuration is written but reconnect fails, the UI reports that
+  the default was saved but the runtime could not reconnect, matching the existing
+  model-switch recovery contract.
+- Provider request failures continue through the existing retry and session-error
+  surfaces; the error includes the attempted model and variant for diagnosis.
+
+## Accessibility and Interaction
+
+- The closed selector is a named button with the active model and reasoning level.
+- The popover supports keyboard search, arrow navigation, Enter to select, and
+  Escape to close without applying changes.
+- Focus returns to the selector after closing and to the composer after applying.
+- Current conversation and default selections use text labels as well as icons;
+  meaning does not depend on color.
+- The selector truncates long model names without moving or shrinking the Send
+  button. The full provider/model identifier is available as accessible text.
+- The control is disabled while a turn is sending or a default-model reconnect is
+  in progress, preventing the displayed selection from diverging mid-turn.
+
+## Verification
+
+Automated coverage must prove:
+
+- The selector renders in the composer immediately before Send.
+- The model catalog is grouped, searchable, and reuses favorites and recent items.
+- Only runtime-reported variants appear; empty variants yield `Provider default`.
+- A conversation-only selection affects prompt bodies but not global config.
+- A default selection updates global config, the current conversation, and the next
+  draft without changing other existing conversations.
+- Draft selection transfers to the newly created session.
+- Switching conversations and restarting restores each conversation's selection.
+- Deleted sessions lose their persisted selection.
+- Every model-mediated send path resolves and passes the same model and variant.
+- Provenance and run records include the active variant.
+- Unavailable models, unavailable variants, catalog failures, write failures, and
+  reconnect failures display the specified states.
+- Keyboard navigation and accessible names cover the closed control and popover.
+
+Manual packaged-app verification must confirm that the selector opens upward,
+stays aligned at narrow window widths, does not displace Send, and that a real
+provider request uses the selected variant when the provider reports support.
+
+## Out of Scope
+
+- Guessing reasoning parameters for custom providers with empty variant metadata.
+- Automatically routing tasks to different models.
+- Changing provider credentials or connection flows.
+- Assigning different models to individual tools or subagents.
+- Redesigning the rest of the composer or Settings page.

--- a/packages/sdk/src/OpenCodeClient.ts
+++ b/packages/sdk/src/OpenCodeClient.ts
@@ -421,12 +421,16 @@ export class OpenCodeClient implements AgentRuntime {
     });
     if (!res.ok) throw await this.apiError(res, "Failed to list providers");
     const body = (await res.json()) as {
-      providers?: Array<{ id: string; name?: string; models?: Record<string, { name?: string }> }>;
+      providers?: Array<{ id: string; name?: string; models?: Record<string, { name?: string; variants?: Record<string, unknown> }> }>
     };
     return (body.providers ?? []).map((p) => ({
       id: p.id,
       name: p.name ?? p.id,
-      models: Object.entries(p.models ?? {}).map(([id, m]) => ({ id, name: m.name ?? id })),
+      models: Object.entries(p.models ?? {}).map(([id, m]) => ({
+        id,
+        name: m.name ?? id,
+        variants: Object.keys(m.variants ?? {}),
+      })),
     }));
   }
 
@@ -680,7 +684,7 @@ export class OpenCodeClient implements AgentRuntime {
    *  default on every turn overrides that stale binding without mutating the
    *  server's stored rows. Omitted/unparseable, the key is left out and the
    *  server falls back to the session/global default. */
-  async sendPrompt(sessionId: string, text: string, agent?: string, model?: string | null): Promise<void> {
+  async sendPrompt(sessionId: string, text: string, agent?: string, model?: string | null, variant?: string | null): Promise<void> {
     const m = parseModel(model);
     const res = await this.fetchWithTimeout(
       `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/prompt_async`,
@@ -691,6 +695,7 @@ export class OpenCodeClient implements AgentRuntime {
           parts: [{ type: "text", text }],
           ...(agent ? { agent } : {}),
           ...(m ? { model: m } : {}),
+          ...(variant ? { variant } : {}),
         }),
       },
     );

--- a/packages/sdk/src/mockServer.ts
+++ b/packages/sdk/src/mockServer.ts
@@ -144,7 +144,7 @@ export function startMockOpenCode(port = 0): Promise<MockOpenCode> {
       res.end(
         JSON.stringify({
           providers: [
-            { id: "mock", name: "Mock Provider", models: { "mock-model": { name: "Mock Model" } } },
+            { id: "mock", name: "Mock Provider", models: { "mock-model": { name: "Mock Model", variants: { low: {}, high: {} } } } },
           ],
         }),
       );

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -44,8 +44,9 @@ export interface AgentRuntime {
   /** `agent` pins a specific agent for the turn (e.g. the read-only "plan"
    *  agent); omit for the runtime default. `model` ("provider/model") pins the
    *  turn to the current default, overriding a session's stale creation-time
-   *  binding; omit to use the session/runtime default. See lib/runtime.ts. */
-  sendPrompt(sessionId: string, text: string, agent?: string, model?: string | null): Promise<void>;
+   *  binding; omit to use the session/runtime default.
+   *  `variant` is an optional reasoning variant ID, e.g. "high", "max". */
+  sendPrompt(sessionId: string, text: string, agent?: string, model?: string | null, variant?: string | null): Promise<void>;
   abortSession(sessionId: string): Promise<void>;
 
   // ---- capability discovery (what this runtime can do) ----

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -237,6 +237,7 @@ export interface OpenCodeClientOptions {
 export interface ProviderModelInfo {
   id: string;
   name: string;
+  variants: string[];
 }
 
 /** A provider OpenCode can use right now (auth present or public). */


### PR DESCRIPTION
## Summary

Adds a model + reasoning effort selector to the Composer action row, replacing the sidebar model pill.

## Changes

- **SDK**:  gains  field;  accepts optional  parameter
- **Pure selection layer** (): resolve/validate/persist per-session and default model selections via localStorage
- **Runtime store**: routes model + variant through per-session state, draft state, and default;  replaces  with full reconnect/error handling
- **Provenance/run logs**: record selected variant alongside model
- **ModelEffortSelector component**: dual-column popover — left: provider-grouped model list with search; right: Thinking toggle + 7 effort levels (Minimal→Ultra)
- **Composer**: integrated selector into action row; removed sidebar model row from StatusPills
- **i18n**: 7 locales updated

## Test plan

- [x] `pnpm typecheck` passes
- [x] 566 tests pass (4 pre-existing unhandled rejections in ComposerAttach unchanged)
- [x] `tauri build` succeeds, .app + .dmg produced
- [x] Manual: select model, select effort, send message — works end-to-end
