### PR TITLE
fix(test): load localStorage shim before @/i18n import in setup

### DIFF
--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -1,5 +1,4 @@
 import "@testing-library/jest-dom/vitest";
-import "@/i18n";
 
 // DOM stubs — only in a browser-like (jsdom) environment. The node-env tests
 // (e.g. the OpenCode integration test) skip these.
@@ -59,3 +58,9 @@ if (typeof window !== "undefined") {
     });
   }
 }
+
+// Import i18n AFTER the localStorage shim is installed: `@/i18n` calls
+// `detectInitialLocale()` at module init, which reads localStorage. A static
+// top-of-file `import "@/i18n"` is hoisted above the shim and crashes under
+// jsdom 25 / Node 25 where `window.localStorage.getItem` is not yet a function.
+await import("@/i18n");


### PR DESCRIPTION
## What

`apps/desktop/src/test/setup.ts` had a static `import "@/i18n"` at the top of the file. ES module imports are hoisted, so this ran **before** the in-memory localStorage shim defined further down the same file. `@/i18n` calls `detectInitialLocale()` at module init, which reads `localStorage` — and under **jsdom 25 / Node 25** that throws `getItem is not a function`, failing every jsdom test suite at load.

The shim from commit `42c8101` was therefore effectively dead code in newer Node environments.

## Fix

Move the i18n import to the end of the file via a dynamic `await import("@/i18n")` so it runs after the shim is installed. Logic-preserving reorder; no behavior change.

## Verification

Before (master `3f3fd9b`, Node 25.8.2):
```
Test Files  85 failed | 1 passed (86)
Tests       18 passed (18)
```

After:
```
Test Files  85 passed (85)
Tests       577 passed (577)
```

Matches the "577 green" reported in PROGRESS.md (likely reproducible on older Node majors where the import-ordering issue does not surface).

One-line change, isolated, no other files touched. Seeking review.