### PR TITLE
Archive sessions under projects

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,9 @@
 # Progress
 
+2026-07-21 11:16 · fix(desktop): normalize Windows drive, verbatim, and UNC workspace paths before project/session matching, so project sessions archive under the correct sidebar directory on Windows. 567 frontend tests, typecheck, and lint pass.
+
+2026-07-21 09:56 · feat(desktop): archive top-level sessions under exact-root projects in the sidebar; unmatched and example sessions remain in history, all projects stay discoverable, and the cross-workspace session catalog is preserved across switches and transient refresh failures. 565 frontend tests, typecheck, lint, and production build pass.
+
 2026-07-20 03:39 · chore(release): v0.2.2 — Settings UI redesign (flat low-chrome controls), SSE render-storm fix (#34), model-switch self-heal guard + custom-provider disconnect auth (#37), privacy header fix. Tagged v0.2.2; CI (build.yml) builds the macOS/Windows/Linux installers into a draft GitHub Release. Zenodo DOI to sync after publishing.
 
 2026-07-20 02:58 · refactor(desktop): redesign Settings UI (UI-only, no behavior change) — replaced bordered controls-inside-cards ("box-in-box") with one low-chrome language: borderless filled "well" inputs, right-aligned transparent dropdown chips (fill on hover), and soft-filled ghost buttons (inputCls.ts + btnGhost). Grouped Runtime's server/proxy/mirrors into one card of rows; flattened the surface-2 add-form panels in Providers/MCP/Compute and the ModelBrowser's inner frame + shaded sidebar (transparent filters, faint dividers, borderless rows); read-only paths (workspace, Python) are plain mono text; Appearance theme lost its segmented track and language became a chip; Privacy reworked into a two-side data-flow with tinted icons + hairline rows. +1 i18n key (runtime.serverLabel) across 7 locales. lint + tsc + vite build clean; 35 settings tests pass. (Worktree.)

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 # macos-private-api: transparent webview background for the vibrancy sidebar
-# (tauri.macos.conf.json); no-op on other platforms.
+# (tauri.macos.conf.json); Tauri CLI syncs this per target during builds.
 tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-shell = "2"
 tauri-plugin-single-instance = "2"

--- a/apps/desktop/src/app/routes/ProjectsPage.test.tsx
+++ b/apps/desktop/src/app/routes/ProjectsPage.test.tsx
@@ -57,4 +57,63 @@ describe("ProjectsPage", () => {
     });
     expect(screen.getByText("No projects match.")).toBeInTheDocument();
   });
+
+  it("expands only exact top-level sessions in newest-first order", async () => {
+    useRuntimeStore.setState({
+      projects: [{ ...base, id: "p1", name: "Alpha", path: "/base/alpha-dir" }],
+      sessions: [
+        { id: "older", title: "older exact session", directory: "/base/alpha-dir", updated: 2_000 },
+        { id: "trailing", title: "trailing slash session", directory: "/base/alpha-dir/", updated: 3_000 },
+        { id: "child-dir", title: "child directory session", directory: "/base/alpha-dir/child", updated: 5_000 },
+        {
+          id: "subagent",
+          title: "subagent session",
+          directory: "/base/alpha-dir",
+          parentId: "older",
+          updated: 6_000,
+        },
+        { id: "newer", title: "newer exact session", directory: "/base/alpha-dir", updated: 4_000 },
+      ],
+    });
+
+    renderAt("/projects");
+    await screen.findByPlaceholderText("Search projects");
+    const page = within(screen.getByRole("main"));
+
+    fireEvent.click(page.getByRole("button", { name: "Alpha" }));
+
+    const newer = page.getByText("newer exact session");
+    const trailing = page.getByText("trailing slash session");
+    const older = page.getByText("older exact session");
+    expect(page.queryByText("child directory session")).not.toBeInTheDocument();
+    expect(page.queryByText("subagent session")).not.toBeInTheDocument();
+    expect(newer.compareDocumentPosition(trailing)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(trailing.compareDocumentPosition(older)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("uses session created time when sorting sessions and project recency without updated", async () => {
+    useRuntimeStore.setState({
+      projects: [
+        { ...base, id: "old-project", name: "Old project", path: "/base/old-project", createdAt: 100 },
+        { ...base, id: "created-only", name: "Created-only latest", path: "/base/created-only", createdAt: 10 },
+      ],
+      sessions: [
+        { id: "older", title: "older created session", directory: "/base/created-only", created: 300 },
+        { id: "newer", title: "newer created session", directory: "/base/created-only", created: 500 },
+      ],
+    });
+
+    renderAt("/projects");
+    await screen.findByPlaceholderText("Search projects");
+    const page = within(screen.getByRole("main"));
+
+    const createdOnly = page.getByRole("button", { name: "Created-only latest" });
+    const oldProject = page.getByRole("button", { name: "Old project" });
+    expect(createdOnly.compareDocumentPosition(oldProject)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    fireEvent.click(createdOnly);
+    const newer = page.getByText("newer created session");
+    const older = page.getByText("older created session");
+    expect(newer.compareDocumentPosition(older)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
 });

--- a/apps/desktop/src/app/routes/ProjectsPage.tsx
+++ b/apps/desktop/src/app/routes/ProjectsPage.tsx
@@ -14,7 +14,12 @@ import type { SessionMeta } from "@ai4s/sdk";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { cn } from "@/lib/cn";
 import { useRuntimeStore } from "@/lib/runtime";
-import { openProjectFolder, renameProject, type ProjectInfo } from "@/lib/tauri";
+import {
+  openProjectFolder,
+  renameProject,
+  workspacePathKey,
+  type ProjectInfo,
+} from "@/lib/tauri";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 /** Compact "time ago" like the reference UI: 37m · 18h · 3d · 1w · 9mo · 2y.
@@ -35,6 +40,8 @@ function timeAgo(ms: number | undefined, now: number): string {
   if (mo < 12) return `${mo}mo`;
   return `${Math.floor(d / 365)}y`;
 }
+
+const sessionRecency = (s: SessionMeta) => s.updated ?? s.created ?? 0;
 
 /** The last path segment (folder name) of an absolute workspace path. */
 function baseName(path: string): string {
@@ -68,12 +75,13 @@ export function ProjectsPage() {
     const map = new Map<string, SessionMeta[]>();
     for (const s of sessions) {
       if (s.parentId || !s.directory) continue;
-      const list = map.get(s.directory) ?? [];
+      const key = workspacePathKey(s.directory);
+      const list = map.get(key) ?? [];
       list.push(s);
-      map.set(s.directory, list);
+      map.set(key, list);
     }
     for (const list of map.values()) {
-      list.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0));
+      list.sort((a, b) => sessionRecency(b) - sessionRecency(a));
     }
     return map;
   }, [sessions]);
@@ -82,8 +90,8 @@ export function ProjectsPage() {
     const q = query.trim().toLowerCase();
     return projects
       .map((p) => {
-        const projectSessions = sessionsByPath.get(p.path) ?? [];
-        const latest = projectSessions[0]?.updated ?? 0;
+        const projectSessions = sessionsByPath.get(workspacePathKey(p.path)) ?? [];
+        const latest = projectSessions[0] ? sessionRecency(projectSessions[0]) : 0;
         return { ...p, sessions: projectSessions, updated: Math.max(latest, p.createdAt) };
       })
       .filter((p) => !q || p.name.toLowerCase().includes(q))
@@ -259,7 +267,7 @@ export function ProjectsPage() {
                             className="grid w-full grid-cols-[minmax(0,1fr)_5rem_1.5rem] items-center gap-3 rounded-input py-1.5 pl-8 pr-2 text-left hover:bg-surface-2"
                           >
                             <span className="truncate text-sm text-text">{s.title}</span>
-                            <span className="text-xs tabular-nums text-muted">{timeAgo(s.updated, now)}</span>
+                            <span className="text-xs tabular-nums text-muted">{timeAgo(sessionRecency(s), now)}</span>
                             <ChevronRight size={14} className="justify-self-end text-muted" />
                           </button>
                         ))

--- a/apps/desktop/src/components/sidebar/Sidebar.projects.test.tsx
+++ b/apps/desktop/src/components/sidebar/Sidebar.projects.test.tsx
@@ -1,4 +1,5 @@
-import { screen } from "@testing-library/react";
+import { screen, within, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import { useRuntimeStore } from "@/lib/runtime";
 import { renderAt } from "@/test/render";
@@ -12,13 +13,265 @@ const PROJECT = {
   pinned: false,
 };
 
-afterEach(() =>
-  useRuntimeStore.setState({ projects: [], sessions: [], workspace: null }),
-);
+const makeProject = (id: string, name: string, extra = {}) => ({
+  id,
+  name,
+  createdAt: 1,
+  path: `/base/${id}`,
+  imported: false,
+  pinned: false,
+  ...extra,
+});
+
+const row = (id: string, title: string, directory?: string, extra = {}) => ({
+  id,
+  title,
+  directory,
+  ...extra,
+});
+
+const expectInOrder = (labels: string[]) => {
+  const elements = labels.map((label) => projectButton(label));
+  for (let i = 0; i < elements.length - 1; i++) {
+    expect(elements[i].compareDocumentPosition(elements[i + 1])).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  }
+};
+
+const projectButton = (name: string): HTMLElement => {
+  const button = screen
+    .getAllByRole("button")
+    .find((button) => button.textContent?.trim().startsWith(name));
+  expect(button, `Expected project button for ${name}`).toBeDefined();
+  return button!;
+};
+const projectBlock = (name: string) => screen.getByRole("group", { name });
+type RuntimePatch = Partial<ReturnType<typeof useRuntimeStore.getState>>;
+
+const setRuntimeState = (state: RuntimePatch) => {
+  act(() => {
+    useRuntimeStore.setState(state);
+  });
+};
+
+afterEach(() => {
+  window.localStorage.removeItem("ai4s.collapsedProjects");
+  setRuntimeState({ projects: [], sessions: [], workspace: null, hiddenExamples: [] });
+});
 
 describe("Sidebar projects", () => {
+  it("shows all projects instead of limiting recent projects", async () => {
+    setRuntimeState({
+      projects: [1, 2, 3, 4, 5, 6, 7].map((n) =>
+        makeProject(`p${n}`, `Project ${n}`, { createdAt: n }),
+      ),
+    });
+    renderAt("/files");
+
+    for (const n of [1, 2, 3, 4, 5, 6, 7]) {
+      expect(await screen.findByText(`Project ${n}`)).toBeInTheDocument();
+    }
+    expect(screen.queryByRole("button", { name: /See all projects/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("+2")).not.toBeInTheDocument();
+  });
+
+  it("groups only exact-root top-level sessions and keeps child, missing-directory, and subagent rows out of projects", async () => {
+    setRuntimeState({
+      projects: [PROJECT],
+      sessions: [
+        row("root", "root session", PROJECT.path, { updated: 10 }),
+        row("child-dir", "child directory session", `${PROJECT.path}/run-1`, { updated: 20 }),
+        row("missing-dir", "missing directory session", undefined, { updated: 30 }),
+        row("subagent", "subagent session", PROJECT.path, { parentId: "root", updated: 40 }),
+      ],
+    });
+    renderAt("/files");
+
+    expect(await screen.findByText("BCI Trends")).toBeInTheDocument();
+    expect(screen.getByText("root session")).toBeInTheDocument();
+    expect(screen.getByText("child directory session")).toBeInTheDocument();
+    expect(screen.getByText("missing directory session")).toBeInTheDocument();
+    expect(screen.queryByText("subagent session")).not.toBeInTheDocument();
+
+    const projectScope = within(projectBlock("BCI Trends"));
+    expect(projectScope.getByText("root session")).toBeInTheDocument();
+    expect(projectScope.queryByText("child directory session")).not.toBeInTheDocument();
+    expect(projectScope.queryByText("missing directory session")).not.toBeInTheDocument();
+  });
+
+  it("groups sessions whose path only differs by a trailing separator", async () => {
+    setRuntimeState({
+      projects: [PROJECT],
+      sessions: [row("trailing", "trailing slash session", `${PROJECT.path}/`, { updated: 100 })],
+    });
+    renderAt("/files");
+
+    expect(
+      await within(projectBlock("BCI Trends")).findByText("trailing slash session"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("trailing slash session")).toHaveLength(1);
+  });
+
+  it("groups Windows sessions when the project path uses a verbatim prefix", async () => {
+    setRuntimeState({
+      projects: [
+        makeProject("windows", "Windows project", {
+          path: String.raw`\\?\D:\OpenScience\Windows-project`,
+        }),
+      ],
+      workspace: String.raw`D:\OpenScience\Windows-project`,
+      sessions: [
+        row(
+          "windows-session",
+          "Windows archived session",
+          String.raw`D:\OpenScience\Windows-project`,
+          { updated: 100 },
+        ),
+      ],
+    });
+    renderAt("/files");
+
+    const block = await screen.findByRole("group", { name: "Windows project" });
+    expect(within(block).getByText("Windows archived session")).toBeInTheDocument();
+    expect(screen.getAllByText("Windows archived session")).toHaveLength(1);
+    expect(projectButton("Windows project").querySelector(".text-accent")).toBeTruthy();
+  });
+
+  it("groups Windows sessions across verbatim and ordinary UNC paths", async () => {
+    setRuntimeState({
+      projects: [
+        makeProject("unc", "UNC project", {
+          path: String.raw`\\?\UNC\server\share\UNC-project`,
+        }),
+      ],
+      sessions: [
+        row(
+          "unc-session",
+          "UNC archived session",
+          String.raw`\\server\share\UNC-project`,
+          { updated: 100 },
+        ),
+      ],
+    });
+    renderAt("/files");
+
+    expect(
+      await within(projectBlock("UNC project")).findByText("UNC archived session"),
+    ).toBeInTheDocument();
+  });
+
+  it("reflows exact-root sessions as projects are dynamically added and removed", async () => {
+    const moving = row("moving", "auto archived", PROJECT.path, { updated: 100 });
+    setRuntimeState({ projects: [], sessions: [moving] });
+    renderAt("/files");
+
+    expect(await screen.findByText("auto archived")).toBeInTheDocument();
+    expect(screen.queryByText("BCI Trends")).not.toBeInTheDocument();
+    expect(screen.getAllByText("auto archived")).toHaveLength(1);
+
+    setRuntimeState({ projects: [PROJECT] });
+
+    expect(await screen.findByText("BCI Trends")).toBeInTheDocument();
+    expect(within(projectBlock("BCI Trends")).getByText("auto archived")).toBeInTheDocument();
+    expect(screen.getAllByText("auto archived")).toHaveLength(1);
+
+    setRuntimeState({ projects: [] });
+
+    expect(screen.queryByText("BCI Trends")).not.toBeInTheDocument();
+    expect(screen.getByText("auto archived")).toBeInTheDocument();
+    expect(screen.getAllByText("auto archived")).toHaveLength(1);
+  });
+
+  it("sorts pinned projects first, then project recency, with stable name and id ties", async () => {
+    setRuntimeState({
+      projects: [
+        makeProject("z-pin", "Zeta pinned", { pinned: true, createdAt: 1 }),
+        makeProject("beta", "Beta", { createdAt: 50 }),
+        makeProject("alpha-b", "Alpha", { createdAt: 10 }),
+        makeProject("alpha-a", "Alpha", { createdAt: 10 }),
+        makeProject("old", "Old", { createdAt: 1 }),
+      ],
+      sessions: [
+        row("old-root", "old root", "/base/old", { updated: 500 }),
+        row("beta-root", "beta root", "/base/beta", { updated: 300 }),
+        row("alpha-a-root", "alpha-a root", "/base/alpha-a", { updated: 10 }),
+        row("alpha-b-root", "alpha-b root", "/base/alpha-b", { updated: 10 }),
+      ],
+    });
+    renderAt("/files");
+
+    await screen.findByText("Zeta pinned");
+    expectInOrder(["Zeta pinned", "Old", "Beta"]);
+    const alphaBlocks = screen.getAllByRole("group", { name: "Alpha" });
+    expect(alphaBlocks).toHaveLength(2);
+    expect(within(alphaBlocks[0]).getByText("alpha-a root")).toBeInTheDocument();
+    expect(within(alphaBlocks[1]).getByText("alpha-b root")).toBeInTheDocument();
+  });
+
+  it("uses a session created time for project recency when updated is missing", async () => {
+    setRuntimeState({
+      projects: [
+        makeProject("session-created", "Session-created recency", { createdAt: 10 }),
+        makeProject("project-created", "Project-created fallback", { createdAt: 100 }),
+      ],
+      sessions: [
+        row("created-only", "created only", "/base/session-created", { created: 500 }),
+      ],
+    });
+    renderAt("/files");
+
+    await screen.findByText("Session-created recency");
+    expectInOrder(["Session-created recency", "Project-created fallback"]);
+  });
+
+  it("keeps collapsed project sessions out of keyboard focus", async () => {
+    const user = userEvent.setup();
+    setRuntimeState({
+      projects: [PROJECT],
+      sessions: [row("root", "inside project", PROJECT.path, { updated: 10 })],
+    });
+    renderAt("/files");
+
+    const button = await screen.findByRole("button", { name: /^BCI Trends/ });
+    await user.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    const collapsed = screen.getByRole("link", { name: "inside project", hidden: true }).closest("[aria-hidden]");
+    expect(collapsed).toHaveAttribute("inert", "");
+    button.focus();
+    expect(button).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole("link", { name: "inside project", hidden: true })).not.toHaveFocus();
+  });
+
+  it("collapse hides only project sessions and examples remain after loose real sessions", async () => {
+    const user = userEvent.setup();
+    setRuntimeState({
+      projects: [PROJECT],
+      sessions: [
+        row("root", "inside project", PROJECT.path, { updated: 10 }),
+        row("loose", "loose real session", "/base/loose", { updated: 20 }),
+      ],
+    });
+    renderAt("/files");
+
+    await screen.findByText("BCI Trends");
+    const button = projectButton("BCI Trends");
+    const projectSession = screen.getByText("inside project");
+    expect(projectSession.closest("[aria-hidden]")).toHaveAttribute("aria-hidden", "false");
+    await user.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(projectSession.closest("[aria-hidden]")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByText("loose real session")).toBeInTheDocument();
+
+    const loose = screen.getByText("loose real session");
+    const example = screen.getByText("Cross-species atlas figure");
+    expect(loose.compareDocumentPosition(example)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
   it("groups sessions into their project and keeps the rest loose", async () => {
-    useRuntimeStore.setState({
+    setRuntimeState({
       projects: [PROJECT],
       sessions: [
         { id: "in", title: "paper search", directory: PROJECT.path },
@@ -47,7 +300,7 @@ describe("Sidebar projects", () => {
   });
 
   it("badges an imported project (referenced in place, not auto-committed)", async () => {
-    useRuntimeStore.setState({
+    setRuntimeState({
       projects: [{ ...PROJECT, id: "p2", name: "My Repo", path: "/home/me/my-repo", imported: true }],
     });
     renderAt("/files");

--- a/apps/desktop/src/components/sidebar/Sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type HTMLAttributes } from "react";
 import { useTranslation } from "react-i18next";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
@@ -20,7 +20,12 @@ import {
 import type { Project } from "@ai4s/shared";
 import { cn } from "@/lib/cn";
 import { useRuntimeStore } from "@/lib/runtime";
-import { pickFolder, renameProject, type ProjectInfo } from "@/lib/tauri";
+import {
+  pickFolder,
+  renameProject,
+  workspacePathKey,
+  type ProjectInfo,
+} from "@/lib/tauri";
 import {
   SIDEBAR_MAX,
   SIDEBAR_MIN,
@@ -39,6 +44,7 @@ interface Row {
   title: string;
   to: string;
   kind: "session" | "example";
+  recency?: number;
 }
 
 /** Dragging the divider below this pointer x collapses the sidebar; dragging
@@ -48,6 +54,9 @@ const COLLAPSE_BELOW = 140;
 /** Projects the user folded shut (ids). Projects default to open — a
  *  researcher has a handful, and their sessions ARE the sidebar's content. */
 const COLLAPSED_KEY = "ai4s.collapsedProjects";
+type InertAttributes = HTMLAttributes<HTMLDivElement> & { inert?: "" };
+const inertWhenClosed = (open: boolean): InertAttributes =>
+  open ? {} : { inert: "" };
 function initialCollapsedProjects(): string[] {
   if (typeof window === "undefined") return [];
   try {
@@ -185,51 +194,61 @@ export function Sidebar({ project }: { project: Project }) {
     }
   };
 
-  // Subagent child sessions are internals of their parent conversation —
-  // their asks and progress surface there, so they get no row of their own.
-  const topSessions = sessions.filter((s) => !s.parentId);
-  const projectByPath = new Map(projects.map((p) => [p.path, p]));
-  const sessionsByProject = new Map<string, Row[]>(
-    projects.map((p) => [p.id, []]),
+  const { sessionsByProject, looseRows, visibleProjects } = useMemo(() => {
+    // Subagent child sessions are internals of their parent conversation —
+    // their asks and progress surface there, so they get no row of their own.
+    const projectByPath = new Map(projects.map((p) => [workspacePathKey(p.path), p]));
+    const sessionsByProject = new Map<string, Row[]>(
+      projects.map((p) => [p.id, []]),
+    );
+    const updatedByProject = new Map<string, number>();
+    const looseRows: Row[] = [];
+    for (const s of sessions) {
+      if (s.parentId) continue;
+      const recency = s.updated ?? s.created;
+      const row: Row = {
+        id: s.id,
+        title: s.title,
+        to: `/live/${s.id}`,
+        kind: "session",
+        recency,
+      };
+      const owner = s.directory
+        ? projectByPath.get(workspacePathKey(s.directory))
+        : undefined;
+      if (owner) {
+        sessionsByProject.get(owner.id)!.push(row);
+        if (recency != null)
+          updatedByProject.set(owner.id, Math.max(updatedByProject.get(owner.id) ?? 0, recency));
+      } else {
+        looseRows.push(row);
+      }
+    }
+    const byRowRecency = (a: Row, b: Row) => (b.recency ?? 0) - (a.recency ?? 0);
+    for (const rows of sessionsByProject.values()) rows.sort(byRowRecency);
+    looseRows.sort(byRowRecency);
+    const recencyOf = (p: ProjectInfo) => updatedByProject.get(p.id) ?? p.createdAt;
+    const visibleProjects = [...projects].sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+      const recencyDelta = recencyOf(b) - recencyOf(a);
+      if (recencyDelta !== 0) return recencyDelta;
+      const nameDelta = a.name.localeCompare(b.name);
+      if (nameDelta !== 0) return nameDelta;
+      return a.id.localeCompare(b.id);
+    });
+    return { sessionsByProject, looseRows, visibleProjects };
+  }, [projects, sessions]);
+  const exampleRows: Row[] = useMemo(
+    () => project.sessions
+      .filter((e) => !hiddenExamples.includes(e.id))
+      .map((e) => ({
+        id: e.id,
+        title: e.title,
+        to: `/example/${e.id}`,
+        kind: "example" as const,
+      })),
+    [project.sessions, hiddenExamples],
   );
-  const looseRows: Row[] = [];
-  for (const s of topSessions) {
-    const row: Row = {
-      id: s.id,
-      title: s.title,
-      to: `/live/${s.id}`,
-      kind: "session",
-    };
-    const owner = s.directory ? projectByPath.get(s.directory) : undefined;
-    if (owner) sessionsByProject.get(owner.id)!.push(row);
-    else looseRows.push(row);
-  }
-  // Recency per project = its newest session's update time (else its creation).
-  const updatedByProject = new Map<string, number>();
-  for (const s of topSessions) {
-    if (!s.directory || s.updated == null) continue;
-    const owner = projectByPath.get(s.directory);
-    if (owner)
-      updatedByProject.set(owner.id, Math.max(updatedByProject.get(owner.id) ?? 0, s.updated));
-  }
-  const recencyOf = (p: ProjectInfo) => updatedByProject.get(p.id) ?? p.createdAt;
-  // The sidebar shows every pinned project plus the few most-recent others; the
-  // full list (search, delete, …) lives on the Projects page.
-  const RECENT_LIMIT = 5;
-  const byRecency = [...projects].sort((a, b) => recencyOf(b) - recencyOf(a));
-  const visibleProjects = [
-    ...byRecency.filter((p) => p.pinned),
-    ...byRecency.filter((p) => !p.pinned).slice(0, RECENT_LIMIT),
-  ];
-  const hiddenProjectCount = projects.length - visibleProjects.length;
-  const exampleRows: Row[] = project.sessions
-    .filter((e) => !hiddenExamples.includes(e.id))
-    .map((e) => ({
-      id: e.id,
-      title: e.title,
-      to: `/example/${e.id}`,
-      kind: "example" as const,
-    }));
 
   const [pendingDelete, setPendingDelete] = useState<Row | null>(null);
 
@@ -472,10 +491,10 @@ export function Sidebar({ project }: { project: Project }) {
           )}
           {visibleProjects.map((p) => {
             const open = !collapsedProjects.includes(p.id);
-            const active = p.path === workspace;
+            const active = workspace ? workspacePathKey(p.path) === workspacePathKey(workspace) : false;
             const rows = sessionsByProject.get(p.id) ?? [];
             return (
-              <div key={p.id}>
+              <div key={p.id} role="group" aria-label={p.name}>
                 {renamingId === p.id ? (
                   <div className="py-0.5 pl-5 pr-1">
                     <InlineNameInput
@@ -555,6 +574,8 @@ export function Sidebar({ project }: { project: Project }) {
                   </div>
                 )}
                 <div
+                  aria-hidden={!open}
+                  {...inertWhenClosed(open)}
                   className={cn(
                     "grid transition-[grid-template-rows] duration-200 ease-out",
                     open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
@@ -574,15 +595,6 @@ export function Sidebar({ project }: { project: Project }) {
               </div>
             );
           })}
-          {hiddenProjectCount > 0 && (
-            <button
-              onClick={() => navigate("/projects")}
-              className="flex w-full items-center gap-2 rounded-input px-2 py-1 pl-6 text-[13px] text-muted hover:bg-surface-2 hover:text-text"
-            >
-              <span className="truncate">{t("projects.seeAll")}</span>
-              <span className="text-[10px] tabular-nums text-muted">+{hiddenProjectCount}</span>
-            </button>
-          )}
           <div className="mt-3 px-2 py-1 text-xs font-medium uppercase tracking-wider text-muted">
             {t("history.heading")}
           </div>

--- a/apps/desktop/src/components/thread/ComposerAttach.test.tsx
+++ b/apps/desktop/src/components/thread/ComposerAttach.test.tsx
@@ -10,6 +10,12 @@ vi.mock("@/lib/tauri", () => ({
   addBinaryToWorkspace: vi.fn(async () => "pasted.png"),
 }));
 
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn(async () => vi.fn()),
+  }),
+}));
+
 describe("Composer attachments (desktop)", () => {
   it("adds picked files as removable chips and sends them as a file note", async () => {
     const onSend = vi.fn();

--- a/apps/desktop/src/lib/runtime.store.test.ts
+++ b/apps/desktop/src/lib/runtime.store.test.ts
@@ -54,14 +54,26 @@ const mocks = vi.hoisted(() => ({
   startRuntime: vi.fn(async () => "http://127.0.0.1:1"),
   /** Constructor options every OpenCodeClient was created with. */
   clientOpts: [] as Record<string, unknown>[],
+  /** Session list the mock server returns. */
+  sessions: [] as unknown[],
+  /** Next listSessions call throws. */
+  failListSessions: false,
+  logDebug: vi.fn(async () => {}),
 }));
 
 vi.mock("./tauri", () => ({
   isTauri: true,
-  logDebug: async () => {},
+  logDebug: mocks.logDebug,
   detectTools: async () => [],
   startRuntime: mocks.startRuntime,
   workspacePath: async () => "/ws/base",
+  workspacePathKey: (path: string) => {
+    const plain = path.replace(/^\\\\\?\\UNC\\/i, "//").replace(/^\\\\\?\\/i, "");
+    const windowsPath = /^[a-z]:[\\/]/i.test(plain) || /^[\\/]{2}/.test(plain);
+    const normalized = windowsPath ? plain.replace(/\\/g, "/").toLowerCase() : plain;
+    if (normalized === "/" || normalized === "//" || /^[a-z]:\/$/i.test(normalized)) return normalized;
+    return normalized.replace(/\/+$/g, "");
+  },
   setWorkspace: mocks.setWorkspace,
   newDatedWorkspace: mocks.newDatedWorkspace,
   markSession: async () => {},
@@ -100,7 +112,8 @@ vi.mock("@ai4s/sdk", () => {
       this.statusCb("ready");
     }
     async listSessions() {
-      return [];
+      if (mocks.failListSessions) throw new Error("list exploded");
+      return mocks.sessions;
     }
     async listSkills() {
       return [{ name: "stub" }];
@@ -208,6 +221,9 @@ beforeEach(async () => {
   mocks.currentModel = null;
   mocks.providers = [];
   mocks.failSetModel = false;
+  mocks.sessions = [];
+  mocks.failListSessions = false;
+  mocks.logDebug.mockClear();
   mocks.notifyPermissionRequest.mockResolvedValue(true);
   useRuntimeStore.setState({
     currentId: null,
@@ -304,6 +320,23 @@ describe("per-session workspace folders", () => {
     await useRuntimeStore.getState().connectRetry(1);
     expect(useRuntimeStore.getState().status).toBe("error");
     expect(useRuntimeStore.getState().error).toContain("event stream");
+  });
+
+  it("openSession does not reconnect for an equivalent Windows workspace path", async () => {
+    useRuntimeStore.setState({
+      workspace: String.raw`D:\OpenScience\Windows-project`,
+      sessions: [
+        {
+          id: "win",
+          title: "Windows session",
+          directory: "\\\\?\\D:\\OpenScience\\Windows-project\\",
+        },
+      ] as never,
+    });
+
+    await useRuntimeStore.getState().openSession("win");
+
+    expect(mocks.setWorkspace).not.toHaveBeenCalled();
   });
 
   it("a superseded openSession does not start a second, dueling reconnect", async () => {
@@ -547,6 +580,45 @@ describe("per-session workspace folders", () => {
     useRuntimeStore.setState({ currentId: "ses_1", workspacePinned: false });
     await useRuntimeStore.getState().ensureDraftWorkspace();
     expect(mocks.newDatedWorkspace).not.toHaveBeenCalled();
+  });
+});
+
+describe("session list refresh", () => {
+  const globalSessions = [
+    { id: "A", title: "Alpha", directory: "/ws/A" },
+    { id: "B", title: "Beta", directory: "/ws/B", parentId: "A" },
+    { id: "loose", title: "Loose", directory: "/ws/loose" },
+  ];
+
+  it("keeps the old sessions and parents when listSessions rejects", async () => {
+    const oldSessions = globalSessions.slice(0, 2);
+    useRuntimeStore.setState({
+      sessions: oldSessions as never,
+      sessionParents: { B: "A" },
+      status: "ready",
+      error: null,
+    });
+    mocks.failListSessions = true;
+    mocks.logDebug.mockClear();
+
+    await useRuntimeStore.getState().refreshSessions();
+
+    const s = useRuntimeStore.getState();
+    expect(s.sessions).toEqual(oldSessions);
+    expect(s.sessionParents).toEqual({ B: "A" });
+    expect(s.status).toBe("ready");
+    expect(s.error).toBe(null);
+    expect(mocks.logDebug).toHaveBeenCalledWith("refreshSessions FAILED: list exploded");
+  });
+
+  it("keeps A, B, and loose sessions from the global list after a workspace switch reconnect", async () => {
+    mocks.sessions = globalSessions;
+
+    await useRuntimeStore.getState().switchWorkspace({ path: "/ws/other" });
+
+    const s = useRuntimeStore.getState();
+    expect(s.sessions.map((session) => session.id)).toEqual(["A", "B", "loose"]);
+    expect(s.sessionParents).toEqual({ B: "A" });
   });
 });
 

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -34,6 +34,7 @@ import {
   setWorkspace,
   startRuntime,
   workspacePath,
+  workspacePathKey,
   type ApprovalMode,
   type ProjectInfo,
   type ProxyMode,
@@ -1111,8 +1112,9 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
         for (const m of sessions) if (m.parentId) sessionParents[m.id] = m.parentId;
         return { sessions, sessionParents };
       });
-    } catch {
-      /* ignore transient list failures */
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      void logDebug(`refreshSessions FAILED: ${msg}`);
     }
   },
 
@@ -1270,7 +1272,8 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
     // all operate where the session's files live. Sessions with no recorded
     // folder, or that already match the active folder, skip this.
     const dir = get().sessions.find((s) => s.id === id)?.directory;
-    if (dir && dir !== get().workspace) {
+    const workspace = get().workspace;
+    if (dir && (!workspace || workspacePathKey(dir) !== workspacePathKey(workspace))) {
       set({ switching: true });
       try {
         await setWorkspace(dir).catch(() => {});

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -482,6 +482,19 @@ export async function newDatedWorkspace(name: string): Promise<string> {
   return invoke<string>("new_dated_workspace", { name });
 }
 
+/** Normalize absolute workspace paths for identity comparisons. Rust
+ * `canonicalize()` adds a Windows verbatim prefix while OpenCode reports the
+ * ordinary drive path; Windows paths are also case-insensitive. */
+export function workspacePathKey(path: string): string {
+  const plain = path.replace(/^\\\\\?\\UNC\\/i, "//").replace(/^\\\\\?\\/i, "");
+  const windowsPath = /^[a-z]:[\\/]/i.test(plain) || /^[\\/]{2}/.test(plain);
+  const normalized = windowsPath ? plain.replace(/\\/g, "/").toLowerCase() : plain;
+  if (normalized === "/" || normalized === "//" || /^[a-z]:\/$/i.test(normalized)) {
+    return normalized;
+  }
+  return normalized.replace(/\/+$/g, "");
+}
+
 /** A project: a named workspace folder under the base dir, marked by its
  *  `.openscience/project.json`. Sessions group under it by `directory`. */
 export interface ProjectInfo {

--- a/apps/desktop/src/test/opencode-client.node.test.ts
+++ b/apps/desktop/src/test/opencode-client.node.test.ts
@@ -71,6 +71,79 @@ describe("OpenCodeClient ↔ OpenCode server", () => {
     expect(commands[1].source).toBe("skill");
   });
 
+  it("lists sessions from the global endpoint without directory scoping", async () => {
+    const seen: string[] = [];
+    const fetching: typeof fetch = async (input) => {
+      seen.push(String(input));
+      return new Response(
+        JSON.stringify([
+          {
+            id: "A",
+            title: "Project A",
+            slug: "project-a",
+            directory: "/ws/A",
+            time: { created: 10, updated: 20 },
+          },
+          {
+            id: "B",
+            title: "Project B",
+            directory: "/ws/B",
+            parentID: "A",
+            time: { created: 11, updated: 21 },
+          },
+          {
+            id: "loose",
+            slug: "loose",
+            directory: "",
+            parentID: null,
+            time: { created: 12, updated: 22 },
+          },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    const client = new OpenCodeClient({
+      baseUrl: "http://opencode.test",
+      directory: "/active/workspace",
+      fetchImpl: fetching,
+    });
+
+    const sessions = await client.listSessions();
+
+    expect(seen).toEqual(["http://opencode.test/experimental/session"]);
+    expect(sessions).toEqual([
+      { id: "A", title: "Project A", slug: "project-a", directory: "/ws/A", created: 10, updated: 20 },
+      {
+        id: "B",
+        title: "Project B",
+        directory: "/ws/B",
+        parentId: "A",
+        created: 11,
+        updated: 21,
+      },
+      { id: "loose", title: "Untitled", slug: "loose", directory: "", created: 12, updated: 22 },
+    ]);
+  });
+
+  it("throws instead of falling back to scoped sessions when the global session list fails", async () => {
+    const seen: string[] = [];
+    const fetching: typeof fetch = async (input) => {
+      seen.push(String(input));
+      return new Response(JSON.stringify({ name: "RouteMissing", message: "missing route" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+    const client = new OpenCodeClient({
+      baseUrl: "http://opencode.test",
+      directory: "/active/workspace",
+      fetchImpl: fetching,
+    });
+
+    await expect(client.listSessions()).rejects.toThrow(/missing route|Failed to list sessions/);
+    expect(seen).toEqual(["http://opencode.test/experimental/session"]);
+  });
+
   it("runs a shell command: bash tool part + session.idle stream back", async () => {
     const events: OpenCodeEvent[] = [];
     const client = new OpenCodeClient({ baseUrl: `http://127.0.0.1:${server.port}` });

--- a/packages/sdk/src/OpenCodeClient.ts
+++ b/packages/sdk/src/OpenCodeClient.ts
@@ -297,15 +297,11 @@ export class OpenCodeClient implements AgentRuntime {
    *  sidecar's cwd resolves to, so history would appear to change when the user
    *  switches folders; `/experimental/session` lists every project's sessions
    *  (each item still carries its `directory`). The OpenCode version is pinned,
-   *  so the experimental route is stable for us; fall back to `/session` if a
-   *  server ever lacks it. */
+   *  so the experimental route is stable for us. */
   async listSessions(): Promise<SessionMeta[]> {
-    let res = await this.fetchWithTimeout(`${this.baseUrl}/experimental/session`, {
+    const res = await this.fetchWithTimeout(`${this.baseUrl}/experimental/session`, {
       headers: this.headers(),
     });
-    if (!res.ok) {
-      res = await this.fetchWithTimeout(`${this.baseUrl}/session`, { headers: this.headers() });
-    }
     if (!res.ok) throw await this.apiError(res, "Failed to list sessions");
     const arr = (await res.json()) as Array<{
       id: string;

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -38,6 +38,7 @@ export interface AgentRuntime {
 
   // ---- sessions (a conversation) ----
   createSession(): Promise<string>;
+  /** Return the runtime-wide session catalog across all workspaces. */
   listSessions(): Promise<SessionMeta[]>;
   deleteSession(sessionId: string): Promise<void>;
   getMessages(sessionId: string): Promise<HistoryMessage[]>;


### PR DESCRIPTION
## Summary
- Group the global OpenCode session catalog under exact project roots in Sidebar and Projects, while leaving child-directory, subagent, and loose sessions ungrouped.
- Normalize workspace path comparisons for Windows drive/verbatim/UNC paths and trailing separators, and reuse the same comparison when opening historical sessions.
- Keep cross-workspace sessions across reconnects by relying on the runtime-wide experimental session endpoint and preserving old state on transient refresh failures.

## Test plan
- [x] pnpm --filter @ai4s/desktop test
- [x] pnpm --filter @ai4s/desktop typecheck
- [x] pnpm --filter @ai4s/desktop lint
- [x] git diff --check
- [x] pnpm --dir "apps/desktop" exec tauri build --debug --no-bundle --target x86_64-pc-windows-msvc

## Notes
- Windows Tauri build temporarily syncs Cargo features for the target during the build; the committed source keeps macos-private-api enabled for macOS transparent sidebar behavior.
- macOS and Linux installer builds should be validated by the existing release workflow matrix.