### PR TITLE
fix: don't copy workspace files to root when attaching via picker

### DIFF
--- a/apps/desktop/src-tauri/src/artifact_file.rs
+++ b/apps/desktop/src-tauri/src/artifact_file.rs
@@ -462,6 +462,7 @@ pub fn write_workspace_file(
 /// Pick local files via the native open dialog and copy them into the agent
 /// workspace so the agent can read them. Returns workspace-relative names
 /// (deduplicated as name-1.ext, name-2.ext on collision); empty on cancel.
+/// Files already inside the workspace attach in place without copying.
 #[tauri::command]
 pub async fn add_files_to_workspace(app: AppHandle) -> Result<Vec<String>, String> {
     use tauri_plugin_dialog::DialogExt;
@@ -469,9 +470,19 @@ pub async fn add_files_to_workspace(app: AppHandle) -> Result<Vec<String>, Strin
         return Ok(Vec::new()); // user cancelled
     };
     let ws = workspace_dir(&app)?;
+    // Canonicalize once so we can tell whether a picked path already resolves
+    // to somewhere inside the workspace (through symlinks / `..` / case).
+    let ws_canon = ws.canonicalize().unwrap_or_else(|_| ws.clone());
     let mut added = Vec::new();
+    let mut copied = false;
     for file in picked {
         let src = file.into_path().map_err(|e| e.to_string())?;
+        // Already inside the workspace → attach its workspace-relative path in
+        // place rather than copying it to the root.
+        if let Some(rel) = workspace_relative(&ws_canon, &src) {
+            added.push(rel);
+            continue;
+        }
         let name = src
             .file_name()
             .ok_or("picked path has no file name")?
@@ -480,8 +491,9 @@ pub async fn add_files_to_workspace(app: AppHandle) -> Result<Vec<String>, Strin
         let dst_name = unique_name(&ws, &name);
         std::fs::copy(&src, ws.join(&dst_name)).map_err(|e| format!("copy failed: {e}"))?;
         added.push(dst_name);
+        copied = true;
     }
-    if !added.is_empty() {
+    if copied {
         crate::git_snapshot::request_snapshot(&ws);
     }
     Ok(added)


### PR DESCRIPTION
## Problem

When using the native file picker dialog ("Add files" button) to attach a file that already lives inside the workspace — even several subdirectories deep — the file gets copied to the workspace **root** with only its basename. For example, attaching `subfolder/deep/data.csv` creates a duplicate `data.csv` at the workspace root.

## Root cause

`add_files_to_workspace` (the file-picker path) took only `src.file_name()` and copied to `ws.join(filename)` — straight to the root — without checking whether the file was already inside the workspace. The sibling function `add_paths_to_workspace` (drag-and-drop) already had the correct `workspace_relative()` guard (added in the issue #44 fix), but it was never applied to the picker path.

## Fix

Add the same `workspace_relative()` check that `add_paths_to_workspace` already uses. If the picked file is already inside the workspace, reference it in place by its relative path — no copy. Files outside the workspace still copy to the root as before.

## Verification

- All 130 Rust unit tests pass (including `workspace_relative_detects_in_place_files`)
- All 657 TypeScript tests pass
- TypeScript typecheck clean
- Pattern is identical to the already-shipped `add_paths_to_workspace` implementation