### PR TITLE
fix: normalize paths when matching sessions to projects (#69)

### DIFF
--- a/apps/desktop/src/app/routes/HistoryPage.tsx
+++ b/apps/desktop/src/app/routes/HistoryPage.tsx
@@ -121,7 +121,8 @@ export function HistoryPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, showArchived, status]);
 
-  const projectByPath = useMemo(() => new Map(projects.map((p) => [p.path, p])), [projects]);
+  const normPath = (p: string) => p.replace(/[\\/]+$/, "");
+  const projectByPath = useMemo(() => new Map(projects.map((p) => [normPath(p.path), p])), [projects]);
 
   const now = Date.now();
   const byBucket = new Map<TimeBucket, SessionMeta[]>();
@@ -276,7 +277,7 @@ export function HistoryPage() {
               </h2>
               <div className="divide-y divide-border border-t border-border">
                 {group.map((s) => {
-                  const owner = s.directory ? projectByPath.get(s.directory) : undefined;
+                  const owner = s.directory ? projectByPath.get(normPath(s.directory)) : undefined;
                   return (
                     <div
                       key={s.id}
@@ -373,14 +374,14 @@ export function HistoryPage() {
                                     {projects.map((p) => (
                                       <DropdownMenu.Item
                                         key={p.id}
-                                        disabled={p.path === s.directory}
+                                        disabled={s.directory != null && normPath(p.path) === normPath(s.directory)}
                                         onSelect={() => {
                                           patchRow(s.id, { directory: p.path });
                                           void moveSessionToWorkspace(s.id, p.path);
                                         }}
                                         className={cn(
                                           "flex cursor-pointer items-center gap-2 rounded-input px-2 py-1.5 outline-none data-[highlighted]:bg-surface-2",
-                                          p.path === s.directory &&
+                                          s.directory != null && normPath(p.path) === normPath(s.directory) &&
                                             "cursor-default text-muted opacity-60",
                                         )}
                                       >

--- a/apps/desktop/src/app/routes/ProjectsPage.tsx
+++ b/apps/desktop/src/app/routes/ProjectsPage.tsx
@@ -47,13 +47,17 @@ export function ProjectsPage() {
   const now = Date.now();
 
   // Top-level sessions grouped by their workspace path, newest first.
+  // Normalize paths so trailing slashes don't split a project's sessions
+  // into a separate bucket that never matches the project path.
+  const normPath = (p: string) => p.replace(/[\\/]+$/, "");
   const sessionsByPath = useMemo(() => {
     const map = new Map<string, SessionMeta[]>();
     for (const s of sessions) {
       if (s.parentId || !s.directory) continue;
-      const list = map.get(s.directory) ?? [];
+      const key = normPath(s.directory);
+      const list = map.get(key) ?? [];
       list.push(s);
-      map.set(s.directory, list);
+      map.set(key, list);
     }
     for (const list of map.values()) {
       list.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0));
@@ -65,7 +69,7 @@ export function ProjectsPage() {
     const q = query.trim().toLowerCase();
     return projects
       .map((p) => {
-        const projectSessions = sessionsByPath.get(p.path) ?? [];
+        const projectSessions = sessionsByPath.get(normPath(p.path)) ?? [];
         const latest = projectSessions[0]?.updated ?? 0;
         return { ...p, sessions: projectSessions, updated: Math.max(latest, p.createdAt) };
       })

--- a/apps/desktop/src/components/sidebar/Sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/Sidebar.tsx
@@ -267,7 +267,12 @@ export function Sidebar({ project }: { project: Project }) {
   // Subagent child sessions are internals of their parent conversation —
   // their asks and progress surface there, so they get no row of their own.
   const topSessions = sessions.filter((s) => !s.parentId);
-  const projectByPath = new Map(projects.map((p) => [p.path, p]));
+  // Normalize paths for reliable matching: the project path (from Tauri) and
+  // the session directory (from OpenCode) may differ in trailing slashes or
+  // separator style. Strip trailing separators so "/w/proj" and "/w/proj/"
+  // match — the same normalization isInside() uses internally.
+  const normPath = (p: string) => p.replace(/[\\/]+$/, "");
+  const projectByPath = new Map(projects.map((p) => [normPath(p.path), p]));
   const sessionsByProject = new Map<string, Row[]>(
     projects.map((p) => [p.id, []]),
   );
@@ -279,7 +284,8 @@ export function Sidebar({ project }: { project: Project }) {
       to: `/live/${s.id}`,
       kind: "session",
     };
-    const owner = s.directory ? projectByPath.get(s.directory) : undefined;
+    const dir = s.directory ? normPath(s.directory) : undefined;
+    const owner = dir ? projectByPath.get(dir) : undefined;
     if (owner) sessionsByProject.get(owner.id)!.push(row);
     else looseRows.push(row);
   }
@@ -287,7 +293,7 @@ export function Sidebar({ project }: { project: Project }) {
   const updatedByProject = new Map<string, number>();
   for (const s of topSessions) {
     if (!s.directory || s.updated == null) continue;
-    const owner = projectByPath.get(s.directory);
+    const owner = projectByPath.get(normPath(s.directory));
     if (owner)
       updatedByProject.set(owner.id, Math.max(updatedByProject.get(owner.id) ?? 0, s.updated));
   }


### PR DESCRIPTION
Fixes #69

**Root cause:** Session directories from OpenCode and project paths from Tauri could differ in trailing slashes (e.g. `/w/proj` vs `/w/proj/`), causing exact `Map.get()` lookups to fail silently. Sessions fell into `looseRows`, leaving projects showing "No sessions".

**Fix:** Add `normPath()` (strips trailing `/` or `\`) before comparing paths in:
- `Sidebar.tsx`: projectByPath map and session directory lookups
- `HistoryPage.tsx`: projectByPath map, session lookups, and move-to-project disabled state
- `ProjectsPage.tsx`: sessionsByPath map and project session lookups

All 762 tests pass.