### PR TITLE
fix(web): allow creating new sessions in projects from the web UI

### DIFF
--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -2877,32 +2877,37 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
   switchWorkspace: async (target) => {
     set({ switching: true });
     try {
-      // Either way the draft ends up aimed at a real folder: the one the user
-      // picked, or the dated one just materialized (so a file pasted into the
-      // draft and the eventual session share it, rather than the send creating
-      // a second dated folder and orphaning the file).
-      // Both commands answer with the canonical path the runtime resolved —
-      // which is exactly what the session's own `directory` will report, so aim
-      // the draft at that, not at the raw string the caller passed.
-      const landed =
-        "dated" in target ? await newDatedWorkspace(target.dated) : await setWorkspace(target.path);
-      // Reset the local kernel so it respawns in the new folder, then reconnect
-      // the event stream scoped to it (connect() re-reads the active folder —
-      // the sidecar itself keeps running). The switch aims the draft at that
-      // folder, so the next new session lands exactly there.
-      await kernelReset().catch(() => {});
-      set((s) => {
-        // Back to a draft in the new folder — the draft pane must not carry
-        // files from the previous folder. Session panes keep their memory.
-        const panes = { ...s.panes };
-        delete panes[DRAFT_KEY];
-        const sessionAgents = { ...s.sessionAgents };
-        delete sessionAgents[DRAFT_KEY];
-        const draftWorkspaces = { ...s.draftWorkspaces, [target.key ?? DRAFT_KEY]: landed };
-        return { currentId: null, panes, draftWorkspaces, sessionAgents };
-      });
-      await get().connectRetry();
-      await Promise.all([get().refreshSessions(), get().loadCatalog()]);
+      if (isGatewayWeb) {
+        // Web client: cannot call Tauri commands (setWorkspace/newDatedWorkspace).
+        // The gateway already routes sessions to the host's active workspace via
+        // /v1/sessions. Just aim the draft at the target path so the next session
+        // lands there when created through the gateway proxy.
+        const landed = target.path;
+        set((s) => {
+          const panes = { ...s.panes };
+          delete panes[DRAFT_KEY];
+          const sessionAgents = { ...s.sessionAgents };
+          delete sessionAgents[DRAFT_KEY];
+          const draftWorkspaces = { ...s.draftWorkspaces, [target.key ?? DRAFT_KEY]: landed };
+          return { currentId: null, panes, draftWorkspaces, sessionAgents };
+        });
+        await Promise.all([get().refreshSessions(), get().loadCatalog()]);
+      } else {
+        // Desktop: switch the sidecar's workspace directory.
+        const landed =
+          "dated" in target ? await newDatedWorkspace(target.dated) : await setWorkspace(target.path);
+        await kernelReset().catch(() => {});
+        set((s) => {
+          const panes = { ...s.panes };
+          delete panes[DRAFT_KEY];
+          const sessionAgents = { ...s.sessionAgents };
+          delete sessionAgents[DRAFT_KEY];
+          const draftWorkspaces = { ...s.draftWorkspaces, [target.key ?? DRAFT_KEY]: landed };
+          return { currentId: null, panes, draftWorkspaces, sessionAgents };
+        });
+        await get().connectRetry();
+        await Promise.all([get().refreshSessions(), get().loadCatalog()]);
+      }
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err) });
     } finally {

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -432,6 +432,11 @@ let opencodeClient: OpenCodeClient | null = null;
  *  killing every session that child was holding. */
 let acpRuntime: AcpRuntime | null = null;
 let acpRuntimeAgentId: string | null = null;
+/** In web mode, the user-selected project directory that overrides the
+ *  /v1/whoami default.  Persisted across reconnects so session creation,
+ *  SSE, permissions/questions, and file operations all scope to the right
+ *  folder.  None means "use whatever /v1/whoami reports". */
+let webOverrideDirectory: string | null = null;
 let openSessionSeq = 0;
 /** The model the user last DELIBERATELY switched to, and when. A switch does a
  *  masked reconnect, and connect() fires loadCatalog() un-awaited — so the
@@ -978,24 +983,32 @@ async function performTurn(
       // that does not gets its own fresh dated folder
       // (~/Documents/OpenScience/sessions/<date-time>) so its files never pile
       // up in the bare base folder.
-      const chosen = isTauri ? get().draftWorkspaces[draftSrc] : undefined;
-      if (isTauri) {
+      const chosen = get().draftWorkspaces[draftSrc];
+      if (isTauri || (isGatewayWeb && chosen)) {
         set({ switching: true });
         try {
-          if (!chosen) {
-            await newDatedWorkspace(datedWorkspaceName());
-            await kernelReset().catch(() => {});
-          } else if (chosen !== get().workspace) {
-            // The active folder wandered off — opening any session follows it
-            // into that session's folder. Go back to the one this draft was
-            // aimed at, or the session lands wherever the user last looked (#69).
-            await setWorkspace(chosen);
-            await kernelReset().catch(() => {});
+          if (isGatewayWeb && chosen) {
+            // Web client: scope the OpenCodeClient to the selected project.
+            // connect() will read webOverrideDirectory and pass it as
+            // ?directory= on session creation, SSE, permissions, and files.
+            webOverrideDirectory = chosen;
+            await get().connectRetry();
+          } else if (isTauri) {
+            if (!chosen) {
+              await newDatedWorkspace(datedWorkspaceName());
+              await kernelReset().catch(() => {});
+            } else if (chosen !== get().workspace) {
+              // The active folder wandered off — opening any session follows it
+              // into that session's folder. Go back to the one this draft was
+              // aimed at, or the session lands wherever the user last looked (#69).
+              await setWorkspace(chosen);
+              await kernelReset().catch(() => {});
+            }
+            // Always rebuild the scoped client: /new and /clear keep the folder,
+            // but the old session route may have just torn down directory-scoped
+            // SSE, and a first send must not hang on a stale workspace instance.
+            await get().connectRetry();
           }
-          // Always rebuild the scoped client: /new and /clear keep the folder,
-          // but the old session route may have just torn down directory-scoped
-          // SSE, and a first send must not hang on a stale workspace instance.
-          await get().connectRetry();
         } finally {
           set({ switching: false });
         }
@@ -1969,10 +1982,12 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
     const previousWorkspace = get().workspace;
     if (isGatewayWeb) {
       // Web client: same-origin gateway; the pasted token is the OpenCodeClient
-      // password, and the workspace directory comes from /v1/whoami.
+      // password, and the workspace directory comes from /v1/whoami — unless
+      // the user explicitly selected a project via switchWorkspace, in which
+      // case webOverrideDirectory takes precedence.
       baseUrl = gatewayOrigin();
       password = gatewayToken();
-      directory = null;
+      directory = webOverrideDirectory;
       let readOnly = false;
       try {
         const r = await fetch(`${baseUrl}/v1/whoami`, {
@@ -1980,7 +1995,8 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
         });
         if (r.ok) {
           const who = (await r.json()) as { directory?: string; mode?: string };
-          directory = who.directory ?? null;
+          // Only use the whoami directory when no override is set.
+          if (!directory) directory = who.directory ?? null;
           // A read-only token 403s every write — surface that in the UI
           // instead of letting "New session" / the composer fail opaquely.
           readOnly = who.mode === "read-only";
@@ -2879,10 +2895,10 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
     try {
       if (isGatewayWeb) {
         // Web client: cannot call Tauri commands (setWorkspace/newDatedWorkspace).
-        // The gateway already routes sessions to the host's active workspace via
-        // /v1/sessions. Just aim the draft at the target path so the next session
-        // lands there when created through the gateway proxy.
+        // Store the selected directory so the next reconnect scopes session
+        // creation, SSE, permissions/questions, and files to this project.
         const landed = target.path;
+        webOverrideDirectory = landed;
         set((s) => {
           const panes = { ...s.panes };
           delete panes[DRAFT_KEY];
@@ -2891,6 +2907,8 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
           const draftWorkspaces = { ...s.draftWorkspaces, [target.key ?? DRAFT_KEY]: landed };
           return { currentId: null, panes, draftWorkspaces, sessionAgents };
         });
+        // Reconnect so the OpenCodeClient picks up the new directory.
+        await get().connectRetry();
         await Promise.all([get().refreshSessions(), get().loadCatalog()]);
       } else {
         // Desktop: switch the sidecar's workspace directory.

--- a/apps/desktop/src/test/opencode-client.sessions.test.ts
+++ b/apps/desktop/src/test/opencode-client.sessions.test.ts
@@ -237,4 +237,55 @@ describe("OpenCodeClient session edits", () => {
 
     await expect(client.renameSession("ses_1", "x")).rejects.toThrow();
   });
+
+  it("creates a session with ?directory= when a directory is set", async () => {
+    // Regression: in web mode, the user selects a project but the session
+    // was created without ?directory=, so it landed in the host's active
+    // workspace instead of the selected project.
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      calls.push(url.pathname + url.search);
+      if (url.pathname === "/session" && init?.method === "POST") {
+        return new Response(JSON.stringify({ id: "ses_new" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const client = new OpenCodeClient({
+      baseUrl: BASE,
+      directory: "/work/projects/my-project",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const id = await client.createSession("test");
+    expect(id).toBe("ses_new");
+    // The session creation URL must carry the directory.
+    expect(calls).toEqual(["/session?directory=%2Fwork%2Fprojects%2Fmy-project"]);
+  });
+
+  it("creates a session without ?directory= when no directory is set", async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      calls.push(url.pathname + url.search);
+      if (url.pathname === "/session" && init?.method === "POST") {
+        return new Response(JSON.stringify({ id: "ses_new" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const client = new OpenCodeClient({
+      baseUrl: BASE,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const id = await client.createSession();
+    expect(id).toBe("ses_new");
+    expect(calls).toEqual(["/session"]);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the "not running in the desktop app" error when creating a new session under a project from the web UI (Remote Access Gateway mode), **and** ensures the created session actually lands in the selected project directory.

Closes #81.

## Problem

Two distinct issues when the web UI (browser) tries to create a session under a user-selected project:

### 1. Tauri-only call crashes in browser

The `newSessionIn()` function in `Sidebar.tsx` calls `switchWorkspace()`, which calls `setWorkspace()` — a Tauri-only command that throws when `window.__TAURI_INTERNALS__` is absent (i.e., in a browser).

```
Sidebar.newSessionIn(project)
  → startDraftInWorkspace(project.path)
    → switchWorkspace({ path })
      → setWorkspace(path)  // throws: "not running in the desktop app"
```

### 2. Session silently lands in the wrong directory

Even after fixing the crash, three independent information paths are broken in web mode, so the session creation request never carries the selected directory:

**Break point A — first-send ignores draftWorkspaces in web mode.**
`runtime.ts` line 810:
```typescript
const chosen = isTauri ? get().draftWorkspaces[draftSrc] : undefined;
```
`isTauri` is `false` in the browser, so `chosen` is always `undefined`. The user selected a project, `switchWorkspace` stored the path in `draftWorkspaces`, but the first-send logic never reads it.

**Break point B — OpenCodeClient is scoped to /v1/whoami, not the selected project.**
`connect()` lines 1459–1480:
```typescript
if (isGatewayWeb) {
  directory = null;                        // ← cleared
  const who = await fetch('/v1/whoami');   // ← returns the HOST's active workspace
  directory = who.directory;
}
```
`/v1/whoami` returns the desktop host's currently active workspace — not the project the user clicked in the web UI. The `OpenCodeClient` is constructed with this directory, and all subsequent API calls (`createSession`, SSE, permissions, files) route through `?directory=` using it.

**Break point C — switchWorkspace stores the path but does not reconnect.**
The original PR patch stored the path in `draftWorkspaces` but skipped `connectRetry()`. The `OpenCodeClient` instance kept its original `directory` from the initial `connect()` call, so the stored path was never used.

## Fix

Introduce `webOverrideDirectory` — a module-level variable that carries the user-selected project directory in web mode and persists across reconnects.

### switchWorkspace (web mode)
Set `webOverrideDirectory = target.path`, then call `connectRetry()` so the `OpenCodeClient` is reconstructed with the correct directory.

### connect() (web mode)
Initialize `directory = webOverrideDirectory`. Only fall back to the `/v1/whoami` response when no override is set:
```typescript
directory = webOverrideDirectory;
// ...
if (!directory) directory = who.directory ?? null;
```

### first-send block
Read `chosen` from `draftWorkspaces` for both Tauri and web mode (no longer gated on `isTauri`). When web mode has a `chosen` directory, set `webOverrideDirectory` and `connectRetry()` before creating the session. The `createSession()` call uses `dirQuery()` → `?directory=PATH`, so the session is created in the correct project.

### Why this works end-to-end
`OpenCodeClient.createSession()` sends `POST /session?directory=PATH`. The `directory` field is set at construction time and used by `dirQuery()` for all directory-scoped calls: session creation, SSE event stream, permissions/questions, and file operations. By overriding it at `connect()` time, all downstream operations automatically scope to the selected project.

## Testing

- Added regression test: `createSession` with a directory sends `?directory=` in the URL
- Added regression test: `createSession` without a directory sends no query parameter
- Manual testing: web UI "New Session" under a project creates the session in that project (not the host active workspace)

## Files changed

- `apps/desktop/src/lib/runtime.ts` — `webOverrideDirectory`, `switchWorkspace`, `connect()`, first-send logic
- `apps/desktop/src/test/opencode-client.sessions.test.ts` — 2 regression tests
