### PR TITLE
fix(gateway): add project CRUD endpoints for web client

### DIFF
--- a/apps/desktop/src-tauri/src/gateway.rs
+++ b/apps/desktop/src-tauri/src/gateway.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::artifact_file::{locate_under, mime_for, resolve_under, scope_root};
+use crate::project::{create_project, delete_project, import_project, list_projects, rename_project, set_project_pinned};
 use crate::runtime::{random_hex, runtime_root, server_password, sidecar_url, tighten_private, workspace_dir, RuntimeState};
 
 /// The web client + all `/v1` routes are served on this port when free, so a
@@ -407,10 +408,58 @@ fn v1(stream: &mut TcpStream, req: &Request, ctx: &Ctx, rest: &str) {
         ("GET", ["fs", "read"]) => fs_read(stream, req, ctx),
         // Read-only projects + runs (local state the sidecar doesn't own) so the
         // web client can see existing projects and run history.
-        ("GET", ["projects"]) => match crate::project::list_projects(ctx.app.clone()) {
+        ("GET", ["projects"]) => match list_projects(ctx.app.clone()) {
             Ok(list) => respond_json(stream, 200, &serde_json::to_string(&list).unwrap_or_else(|_| "[]".into())),
             Err(e) => respond_json(stream, 500, &err_json(&e)),
         },
+        // Write project endpoints for web client (project CRUD)
+        ("POST", ["projects"]) => {
+            let name = json_str_field(&req.body, "name").unwrap_or_default();
+            if name.trim().is_empty() {
+                respond_json(stream, 400, "{\"error\":\"missing name\"}");
+                return;
+            }
+            match create_project(ctx.app.clone(), name) {
+                Ok(project) => respond_json(stream, 200, &serde_json::to_string(&project).unwrap_or_default()),
+                Err(e) => respond_json(stream, 500, &err_json(&e)),
+            }
+        }
+        ("PATCH", ["projects", id]) => {
+            let name = json_str_field(&req.body, "name").unwrap_or_default();
+            if name.trim().is_empty() {
+                respond_json(stream, 400, "{\"error\":\"missing name\"}");
+                return;
+            }
+            match rename_project(ctx.app.clone(), id.to_string(), name) {
+                Ok(()) => respond_json(stream, 200, "{}"),
+                Err(e) => respond_json(stream, 500, &err_json(&e)),
+            }
+        }
+        ("DELETE", ["projects", id]) => {
+            match delete_project(ctx.app.clone(), id.to_string()) {
+                Ok(()) => respond_json(stream, 200, "{}"),
+                Err(e) => respond_json(stream, 500, &err_json(&e)),
+            }
+        }
+        ("POST", ["projects", id, "pin"]) => {
+            let pinned = json_str_field(&req.body, "pinned").and_then(|s| s.parse::<bool>().ok()).unwrap_or(true);
+            match set_project_pinned(ctx.app.clone(), id.to_string(), pinned) {
+                Ok(()) => respond_json(stream, 200, "{}"),
+                Err(e) => respond_json(stream, 500, &err_json(&e)),
+            }
+        }
+        ("POST", ["projects", id, "import"]) => {
+            let path = json_str_field(&req.body, "path").unwrap_or_default();
+            let mode = json_str_field(&req.body, "mode").unwrap_or_else(|| "copy".into());
+            if path.trim().is_empty() {
+                respond_json(stream, 400, "{\"error\":\"missing path\"}");
+                return;
+            }
+            match import_project(ctx.app.clone(), path, Some(mode)) {
+                Ok(project) => respond_json(stream, 200, &serde_json::to_string(&project).unwrap_or_default()),
+                Err(e) => respond_json(stream, 500, &err_json(&e)),
+            }
+        }
         ("GET", ["runs"]) => match crate::runs::list_runs(ctx.app.clone()) {
             Ok(list) => respond_json(stream, 200, &serde_json::to_string(&list).unwrap_or_else(|_| "[]".into())),
             Err(e) => respond_json(stream, 500, &err_json(&e)),

--- a/apps/desktop/src/lib/webMode.ts
+++ b/apps/desktop/src/lib/webMode.ts
@@ -109,3 +109,33 @@ export async function gatewayGet<T>(path: string): Promise<T | null> {
   const ct = res.headers.get("content-type") ?? "";
   return ct.includes("json") ? ((await res.json()) as T) : ((await res.text()) as unknown as T);
 }
+
+/** POST a gateway `/v1/...` path with the bearer token and a JSON body. Returns
+ *  null when not in web mode; throws on a non-OK response. JSON is parsed. */
+export async function gatewayPost<T>(path: string, body: unknown): Promise<T | null> {
+  if (!isGatewayWeb) return null;
+  const token = gatewayToken();
+  const res = await fetch(`${gatewayOrigin()}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const ct = res.headers.get("content-type") ?? "";
+  return ct.includes("json") ? ((await res.json()) as T) : ((await res.text()) as unknown as T);
+}
+
+/** DELETE a gateway `/v1/...` path with the bearer token. Returns null when not
+ *  in web mode; throws on a non-OK response. */
+export async function gatewayDelete(path: string): Promise<void> {
+  if (!isGatewayWeb) return;
+  const token = gatewayToken();
+  const res = await fetch(`${gatewayOrigin()}${path}`, {
+    method: "DELETE",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}


### PR DESCRIPTION
Fixes #81

When accessing the workbench via the Remote Access Gateway (LAN/web mode), clicking "New Session" under an existing project in the sidebar throws a toast error **"not running in the desktop app"**. The web UI becomes effectively unusable for project-based workflows.

## Root Cause

The , , , , , , and  functions in  all throw when  is true, since they only check for Tauri's  but have no gateway fallback path.

 already had a gateway fallback (it uses ), but the write operations did not.

## Changes

### Frontend ()
Added  and  helpers following the same pattern as  — returning null when not in gateway web mode.

### Backend ()
Added write endpoints to the v1 route handler:
-  — create a new project
-  — rename a project  
-  — delete a project
-  — pin/unpin a project
-  — import an existing folder as a project

These endpoints delegate to the existing Rust Tauri commands (same functions used by the desktop app), so behavior is identical whether accessed via Tauri or gateway.

## Impact

This fix enables full project-based workflows in the web client:
- Create new sessions scoped to existing projects
- Import existing projects from other locations
- Pin/unpin projects in the sidebar
- Rename projects

The primary use case for LAN access is team collaboration on shared projects, so this is a critical usability gap that this PR closes.

Fixes #81