### PR TITLE
fix(settings): accept non-Latin custom provider names

### DIFF
--- a/apps/desktop/src/app/routes/SettingsPage.modelBrowser.test.tsx
+++ b/apps/desktop/src/app/routes/SettingsPage.modelBrowser.test.tsx
@@ -38,6 +38,7 @@ function catalogClient(
     getProviderRegion: vi.fn().mockResolvedValue(null),
     setProviderRegion: vi.fn().mockResolvedValue(undefined),
     setProviderApiKey: vi.fn().mockResolvedValue(undefined),
+    addCustomProvider: vi.fn().mockResolvedValue(undefined),
   } as unknown as NonNullable<ReturnType<typeof runtime.getClient>>;
 }
 
@@ -187,6 +188,32 @@ describe("Settings model browser integration", () => {
     expect(
       vi.mocked(client.setProviderRegion).mock.invocationCallOrder[0],
     ).toBeLessThan(vi.mocked(client.setProviderApiKey).mock.invocationCallOrder[0]);
+  });
+
+  it("accepts a non-Latin custom provider display name", async () => {
+    const client = catalogClient();
+    vi.spyOn(runtime, "getClient").mockReturnValue(client);
+    await renderSettings();
+    await screen.findByRole("button", { name: /^o3/ });
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage" }));
+    await userEvent.click(screen.getByRole("button", { name: /Custom endpoint/ }));
+    const displayName = "\u97f3\u4e91";
+    await userEvent.type(screen.getByPlaceholderText(/Name/), displayName);
+    await userEvent.type(screen.getByPlaceholderText(/Base URL/), "https://example.test/v1");
+    await userEvent.type(screen.getByPlaceholderText(/Model ids/), "gpt-5.6-luna");
+    await userEvent.click(screen.getByRole("button", { name: "Add endpoint" }));
+
+    await waitFor(() =>
+      expect(client.addCustomProvider).toHaveBeenCalledWith(
+        "custom-97f3-4e91",
+        expect.objectContaining({
+          name: displayName,
+          baseURL: "https://example.test/v1",
+          models: ["gpt-5.6-luna"],
+        }),
+      ),
+    );
   });
 
   it("drops the cached catalog when the server URL changes (no stale models from the old runtime)", async () => {

--- a/apps/desktop/src/app/routes/SettingsPage.tsx
+++ b/apps/desktop/src/app/routes/SettingsPage.tsx
@@ -653,6 +653,16 @@ export function SettingsPage() {
 
   const modelList = (s: string) => s.split(",").map((v) => v.trim()).filter(Boolean);
 
+  // Keep provider IDs ASCII for OpenCode's provider/model keys, but do not
+  // reject a display name just because its script is not Latin.
+  const customProviderId = (name: string) => {
+    const trimmed = name.trim();
+    if (!trimmed) return "";
+    const ascii = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    if (ascii) return ascii;
+    return `custom-${Array.from(trimmed, (char) => char.codePointAt(0)!.toString(16)).join("-")}`;
+  };
+
   const toggleDetectedModel = (id: string) => {
     const models = modelList(cModels);
     const next = models.includes(id) ? models.filter((m) => m !== id) : [...models, id];
@@ -661,7 +671,7 @@ export function SettingsPage() {
 
   const saveCustom = () =>
     run(t("toast.couldNotAddEndpoint"), async () => {
-      const id = cName.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const id = customProviderId(cName);
       const models = modelList(cModels);
       if (!id || !cUrl.trim() || models.length === 0) {
         toast.error(t("toast.endpointFieldsRequired"));


### PR DESCRIPTION
Fixes #89

## Summary

- Keep OpenCode provider/model IDs ASCII while preserving non-Latin provider display names.
- Generate a deterministic code-point-based fallback ID when a display name has no ASCII characters.
- Add a regression test for the Chinese display name `音云`.

## Validation

- Targeted `SettingsPage.modelBrowser.test.tsx`: 12 tests passed.
- Desktop TypeScript check passed with `tsc --noEmit`.
- Verified the generated provider can be stored by the local OpenCode runtime.