### PR TITLE
fix(settings): keep non-Latin endpoint names off colliding provider ids

### DIFF
--- a/apps/desktop/src/app/routes/SettingsPage.modelBrowser.test.tsx
+++ b/apps/desktop/src/app/routes/SettingsPage.modelBrowser.test.tsx
@@ -204,9 +204,12 @@ describe("Settings model browser integration", () => {
     await userEvent.type(screen.getByPlaceholderText(/Model ids/), "gpt-5.6-luna");
     await userEvent.click(screen.getByRole("button", { name: "Add endpoint" }));
 
+    // The config key stays ASCII (customProviderId covers how it is derived);
+    // what matters here is that the form accepts the name and passes it through
+    // as the display name instead of reporting a missing field.
     await waitFor(() =>
       expect(client.addCustomProvider).toHaveBeenCalledWith(
-        "custom-97f3-4e91",
+        expect.stringMatching(/^custom-[0-9a-f]{8}$/),
         expect.objectContaining({
           name: displayName,
           baseURL: "https://example.test/v1",

--- a/apps/desktop/src/app/routes/SettingsPage.tsx
+++ b/apps/desktop/src/app/routes/SettingsPage.tsx
@@ -59,6 +59,7 @@ import {
   type ProbedModel,
 } from "@/lib/tauri";
 import { useSetupStore } from "@/lib/setup";
+import { customProviderId } from "@/lib/customProviderId";
 import { RemoteComputeCard } from "@/components/settings/RemoteComputeCard";
 import { RemoteAccessCard } from "@/components/settings/RemoteAccessCard";
 import { AcpAgentsCard } from "@/components/settings/AcpAgentsCard";
@@ -648,16 +649,6 @@ export function SettingsPage() {
   };
 
   const modelList = (s: string) => s.split(",").map((v) => v.trim()).filter(Boolean);
-
-  // Keep provider IDs ASCII for OpenCode's provider/model keys, but do not
-  // reject a display name just because its script is not Latin.
-  const customProviderId = (name: string) => {
-    const trimmed = name.trim();
-    if (!trimmed) return "";
-    const ascii = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-    if (ascii) return ascii;
-    return `custom-${Array.from(trimmed, (char) => char.codePointAt(0)!.toString(16)).join("-")}`;
-  };
 
   const toggleDetectedModel = (id: string) => {
     const models = modelList(cModels);

--- a/apps/desktop/src/lib/customProviderId.test.ts
+++ b/apps/desktop/src/lib/customProviderId.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { customProviderId } from "./customProviderId";
+
+describe("customProviderId", () => {
+  it("slugifies an ASCII name unchanged, so existing endpoints keep their ids", () => {
+    expect(customProviderId("OpenRouter")).toBe("openrouter");
+    expect(customProviderId("Ollama local")).toBe("ollama-local");
+    expect(customProviderId("  My Endpoint v2  ")).toBe("my-endpoint-v2");
+  });
+
+  it("accepts a name with no ASCII characters at all (#89)", () => {
+    const id = customProviderId("音云");
+    expect(id).not.toBe("");
+    expect(id).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it("is stable for the same name", () => {
+    expect(customProviderId("音云")).toBe(customProviderId("音云"));
+  });
+
+  it("keeps names that share an ASCII skeleton on distinct ids", () => {
+    // Both collapse to "api" on the slug alone; colliding here would make the
+    // second "Add endpoint" overwrite the first provider's config.
+    expect(customProviderId("音云 API")).not.toBe(customProviderId("星河 API"));
+    expect(customProviderId("音云")).not.toBe(customProviderId("大模型"));
+  });
+
+  it("bounds the id length for a long non-Latin name", () => {
+    expect(customProviderId("智谱清言大模型服务平台").length).toBeLessThanOrEqual(16);
+  });
+
+  it("returns an id for a name that slugifies to nothing", () => {
+    expect(customProviderId("!!!")).toMatch(/^custom-[0-9a-f]{8}$/);
+  });
+
+  it("returns \"\" only for a blank name", () => {
+    expect(customProviderId("")).toBe("");
+    expect(customProviderId("   ")).toBe("");
+  });
+});

--- a/apps/desktop/src/lib/customProviderId.ts
+++ b/apps/desktop/src/lib/customProviderId.ts
@@ -1,0 +1,41 @@
+// Derives the id a custom endpoint gets in OpenCode's global config from the
+// display name the user typed. The id becomes a JSON key under `provider` and
+// rides inside "provider/model" strings, so it stays ASCII — but a display name
+// must not have to be (#89).
+//
+// An ASCII-only name keeps its plain slug, so endpoints added before this
+// existed keep the ids they already have. Once a name carries non-ASCII
+// characters the slug has dropped information, so a digest of the whole name is
+// appended: without it "音云 API" and "星河 API" both collapse to `api`, and the
+// second "Add endpoint" silently overwrites the first provider's config.
+
+function isAscii(s: string): boolean {
+  for (const ch of s) if (ch.codePointAt(0)! > 0x7f) return false;
+  return true;
+}
+
+/** FNV-1a over code points — short, stable, and needs no crypto import. */
+function digest(s: string): string {
+  let h = 0x811c9dc5;
+  for (const ch of s) {
+    h ^= ch.codePointAt(0)!;
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * ASCII config id for a custom endpoint's display name. Returns "" only for a
+ * blank name, so callers can treat "" as "the name field is empty".
+ */
+export function customProviderId(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+  const slug = trimmed
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  if (!slug) return `custom-${digest(trimmed)}`;
+  if (isAscii(trimmed)) return slug;
+  return `${slug}-${digest(trimmed)}`;
+}


### PR DESCRIPTION
Follow-up to #90 (see [review note](https://github.com/ai4s-research/open-science/pull/90#pullrequestreview-0)).

#90 fixed the reported case in #89 — a name with no ASCII characters at all no longer reads as a missing field. Two things next to it were left open, one of them lossy:

- The fallback only fired when the slug was **completely** empty, so a mixed name still collapsed to its ASCII fragment. `音云 API` and `星河 API` both became `api`, and since the id is the key under `provider` in OpenCode's global config, the second **Add endpoint** silently overwrote the first provider. The collision class is pre-existing on `master`, but #90 makes non-Latin names a normal thing to type, so it became easy to hit.
- The codepoint-join id was unbounded: `智谱清言大模型服务平台` produced a 56-character key.

## Change

Moves the derivation out of `SettingsPage` into `lib/customProviderId.ts` (matching the small-pure-module-plus-colocated-test pattern in `lib/`) and appends a short FNV-1a digest of the whole name whenever the name carries non-ASCII characters:

| name | before | after |
|---|---|---|
| `OpenRouter` | `openrouter` | `openrouter` |
| `Ollama local` | `ollama-local` | `ollama-local` |
| `音云` | `custom-97f3-4e91` | `custom-fb3f4e69` |
| `音云 API` | `api` | `api-68e727b9` |
| `星河 API` | `api` ⚠️ same | `api-2d166627` |
| `智谱清言大模型服务平台` | 56 chars | `custom-e0f6c973` |

**ASCII-only names keep their plain slug**, so every endpoint added before this keeps the id it already has — no migration, no orphaned provider config.

Also makes the id non-empty for any non-blank name (`!!!` used to slugify to `""` and trip the "required fields" toast), so `""` now means exactly "the name field is blank".

## Validation

- `customProviderId.test.ts` — 7 new tests (ASCII stability, non-Latin acceptance, determinism, skeleton-collision distinctness, length bound, blank handling)
- `SettingsPage.modelBrowser.test.tsx` — 12 pass; the non-Latin case now pins the id *shape* rather than a hardcoded digest, so it tests the contract instead of restating the implementation
- `tsc --noEmit` and `eslint` clean