### PR TITLE
fix(session): send image attachments as multimodal parts, not just a filename

### DIFF
--- a/apps/desktop/src/components/session/SessionView.tsx
+++ b/apps/desktop/src/components/session/SessionView.tsx
@@ -175,9 +175,9 @@ export function SessionView({
   const onSplit = (edge: "right" | "bottom") => {
     dockSession(leafId, edge, null);
   };
-  const onSend = async (text: string) => {
+  const onSend = async (text: string, attachments?: string[]) => {
     pinEphemeral();
-    bindIfCreated(await sendPrompt(text, sid ?? undefined, draftKey));
+    bindIfCreated(await sendPrompt(text, sid ?? undefined, draftKey, attachments));
   };
   const onRunShell = async (command: string) => {
     pinEphemeral();

--- a/apps/desktop/src/components/thread/Composer.tsx
+++ b/apps/desktop/src/components/thread/Composer.tsx
@@ -147,7 +147,9 @@ export function Composer({
   currentSessionId,
   onInteract,
 }: {
-  onSend?: (text: string) => void;
+  /** `attachments` are the chip file names, omitted when there are none. The
+   *  text already names them; the list lets the send attach the images too. */
+  onSend?: (text: string, attachments?: string[]) => void;
   onRunShell?: (command: string) => void;
   onRunCommand?: (name: string, args: string) => void;
   commands?: ComposerCommand[];
@@ -446,16 +448,21 @@ export function Composer({
     const fileNote =
       files.length > 0 ? `Files added to the workspace: ${files.join(", ")}` : "";
     const base = text && fileNote ? `${text}\n\n${fileNote}` : text || fileNote;
+    // The chips travel with the text: the note names the workspace copy, and the
+    // names let the send turn images into real multimodal parts (#88). Passed
+    // only when there are chips, so a plain send keeps its one-argument shape.
+    const attachments = files.length > 0 ? [...files] : null;
+    const send = (t: string) => (attachments ? onSend?.(t, attachments) : onSend?.(t));
     if (refSessions.length > 0) {
       // Referenced conversations are fetched and condensed before sending, so
       // the agent gets the earlier context without the user copy-pasting it.
       const attached = [...refSessions];
       setRefSessions([]);
       void buildReferences(attached).then((blocks) =>
-        onSend?.(blocks ? `${blocks}\n\n${base}` : base),
+        send(blocks ? `${blocks}\n\n${base}` : base),
       );
     } else {
-      onSend?.(base);
+      send(base);
     }
     if (text) recordHistory(text);
     setValue("");

--- a/apps/desktop/src/components/thread/ComposerAttach.test.tsx
+++ b/apps/desktop/src/components/thread/ComposerAttach.test.tsx
@@ -32,8 +32,11 @@ describe("Composer attachments (desktop)", () => {
     fireEvent.change(input, { target: { value: "analyze this" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
+    // The note names the workspace copy; the chip list rides along so the send
+    // can also attach the images as real multimodal parts (#88).
     expect(onSend).toHaveBeenCalledWith(
       "analyze this\n\nFiles added to the workspace: data.csv",
+      ["data.csv"],
     );
     // Chips are cleared after sending.
     expect(screen.queryByText("data.csv")).toBeNull();

--- a/apps/desktop/src/lib/promptAttachments.test.ts
+++ b/apps/desktop/src/lib/promptAttachments.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArtifactFile } from "./artifactFile";
+import { imageAttachmentParts } from "./promptAttachments";
+import * as artifactFile from "./artifactFile";
+
+const file = (over: Partial<ArtifactFile>): ArtifactFile => ({
+  path: "x",
+  mime: "image/png",
+  encoding: "base64",
+  data: "AAAA",
+  size: 4,
+  ...over,
+});
+
+describe("imageAttachmentParts", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("sends an image as a data-URL part (a file:// url loses the whole turn)", async () => {
+    vi.spyOn(artifactFile, "readArtifact").mockResolvedValue(
+      file({ mime: "image/png", data: "UE5H" }),
+    );
+    expect(await imageAttachmentParts(["figure.png"])).toEqual([
+      { filename: "figure.png", mime: "image/png", url: "data:image/png;base64,UE5H" },
+    ]);
+  });
+
+  it("reads nothing when there are no attachments", async () => {
+    const read = vi.spyOn(artifactFile, "readArtifact");
+    expect(await imageAttachmentParts([])).toEqual([]);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("leaves non-images to the agent's own file tools", async () => {
+    vi.spyOn(artifactFile, "readArtifact").mockResolvedValue(
+      file({ mime: "text/csv", encoding: "utf8", data: "a,b" }),
+    );
+    expect(await imageAttachmentParts(["data.csv"])).toEqual([]);
+  });
+
+  it("skips an image too large to inline rather than stalling the turn", async () => {
+    vi.spyOn(artifactFile, "readArtifact").mockResolvedValue(
+      file({ mime: "image/png", size: 64 * 1024 * 1024 }),
+    );
+    expect(await imageAttachmentParts(["huge.png"])).toEqual([]);
+  });
+
+  it("drops an unreadable attachment without failing the others", async () => {
+    vi.spyOn(artifactFile, "readArtifact").mockImplementation(async (path) => {
+      if (path === "gone.png") throw new Error("ENOENT");
+      return file({ mime: "image/jpeg", data: "SkZH" });
+    });
+    expect(await imageAttachmentParts(["gone.png", "kept.jpg"])).toEqual([
+      { filename: "kept.jpg", mime: "image/jpeg", url: "data:image/jpeg;base64,SkZH" },
+    ]);
+  });
+
+  it("attaches nothing outside the desktop app (readArtifact returns null)", async () => {
+    vi.spyOn(artifactFile, "readArtifact").mockResolvedValue(null);
+    expect(await imageAttachmentParts(["figure.png"])).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/promptAttachments.ts
+++ b/apps/desktop/src/lib/promptAttachments.ts
@@ -1,0 +1,46 @@
+// Turn composer attachments into real multimodal prompt parts (#88).
+//
+// An attachment is already copied into the workspace, and the prompt text names
+// it — enough for the agent to open it with its own tools, but not enough for a
+// vision model to LOOK at a figure: it only ever saw the filename. Images are
+// therefore also sent as `file` parts carrying the bytes.
+//
+// Images only, deliberately. Anything else (CSV, notebook, PDF, archive) is
+// better read by the agent's own tools than inlined into every request, and the
+// workspace note already points at it.
+
+import type { PromptFile } from "@ai4s/sdk";
+import { readArtifact, toDataUrl } from "./artifactFile";
+
+/** Formats a vision model can be expected to accept. */
+const IMAGE_MIME = /^image\/(png|jpe?g|gif|webp)$/i;
+
+/**
+ * Base64 inflates by ~4/3, and the whole part rides inside one JSON request, so
+ * a huge image would stall or blow up the turn. Above this the attachment stays
+ * a workspace note — the agent can still open the file.
+ */
+const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
+
+/**
+ * Resolve workspace attachment names to image parts. Never throws and never
+ * blocks a send: anything unreadable, oversized, or not an image is simply
+ * omitted, leaving the prompt's file note as the only reference to it.
+ */
+export async function imageAttachmentParts(names: string[]): Promise<PromptFile[]> {
+  if (names.length === 0) return [];
+  const parts = await Promise.all(
+    names.map(async (filename): Promise<PromptFile | null> => {
+      try {
+        const file = await readArtifact(filename);
+        if (!file || file.encoding !== "base64") return null;
+        if (!IMAGE_MIME.test(file.mime)) return null;
+        if (file.size > MAX_IMAGE_BYTES) return null;
+        return { filename, mime: file.mime, url: toDataUrl(file) };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return parts.filter((p): p is PromptFile => p !== null);
+}

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -60,6 +60,7 @@ import { moveScrollMemory } from "./scrollMemory";
 import { deriveArtifact, deriveArtifactPresentation } from "./artifacts";
 import { useLayoutStore } from "./layout";
 import { provenanceInputsFromEvent, recordProvenance } from "./provenance";
+import { imageAttachmentParts } from "./promptAttachments";
 import { recordRun, runInputFromEvent } from "./runs";
 import { splitReview } from "./review";
 import { useSshStore } from "./ssh";
@@ -343,7 +344,14 @@ interface RuntimeState {
   /** `draftKey` (a `draft:<leafId>` slot) is the per-pane draft this send may
    *  lazily create a session from — passed by tiled panes so each unbound pane
    *  keeps its own draft/thread and creates its own session on first send. */
-  sendPrompt: (text: string, sessionId?: string, draftKey?: string) => Promise<string | null>;
+  /** `attachments` are workspace file names from the composer's chips; the image
+   *  ones are also sent as multimodal parts so a vision model sees them (#88). */
+  sendPrompt: (
+    text: string,
+    sessionId?: string,
+    draftKey?: string,
+    attachments?: string[],
+  ) => Promise<string | null>;
   /** Run a "!" shell command directly in the session's workspace folder —
    *  no model turn; the output folds into the thread as a bash tool row. */
   runShell: (command: string, sessionId?: string, draftKey?: string) => Promise<string | null>;
@@ -2920,7 +2928,7 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
 
   // The send lifecycle (new → input → send → response) is shared by plain
   // prompts, "!" shell commands and "/" slash commands — see performTurn.
-  sendPrompt: (text, sessionId, draftKey) => {
+  sendPrompt: (text, sessionId, draftKey, attachments) => {
     // Capture the mode BEFORE performTurn: on a draft, currentId is still null
     // here (the session is created inside), so this reads the pane's draft slot
     // correctly. Pin "plan" only when the catalog actually has it — a stale mode
@@ -2938,7 +2946,13 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
       set,
       get,
       text,
-      (sid) => withRetry(() => client!.sendPrompt(sid, text, agent, model, variant)),
+      // Attachment bytes are read INSIDE the send, not before performTurn: the
+      // echo and the spinner must appear on click, not after a multi-MB read.
+      (sid) =>
+        withRetry(async () => {
+          const files = await imageAttachmentParts(attachments ?? []);
+          await client!.sendPrompt(sid, text, agent, model, variant, files);
+        }),
       // An ACP turn is a SYNC turn: `session/prompt` is one JSON-RPC request that
       // answers when the turn is over, where OpenCode's `prompt_async` answers as
       // soon as it is accepted. Without this the running lock would be taken

--- a/apps/desktop/src/test/opencode-client.node.test.ts
+++ b/apps/desktop/src/test/opencode-client.node.test.ts
@@ -592,3 +592,32 @@ describe("per-prompt model pinning (#8: old sessions follow the current default)
     client.close();
   });
 });
+
+describe("image attachments (#88: a vision model must see the figure, not its name)", () => {
+  it("sends each attachment as a file part beside the text, and none when there are none", async () => {
+    const client = new OpenCodeClient({ baseUrl: `http://127.0.0.1:${server.port}` });
+    await client.connect();
+    const sessionId = await client.createSession();
+    const before = server.promptBodies.length;
+
+    await client.sendPrompt(sessionId, "inspect this figure", undefined, null, null, [
+      { filename: "pasted.png", mime: "image/png", url: "data:image/png;base64,UE5H" },
+    ]);
+    await client.sendPrompt(sessionId, "no attachment");
+
+    const bodies = server.promptBodies.slice(before) as Array<{ parts: Array<Record<string, unknown>> }>;
+    expect(bodies[0].parts).toEqual([
+      { type: "text", text: "inspect this figure" },
+      {
+        type: "file",
+        mime: "image/png",
+        filename: "pasted.png",
+        // A data: URL, never file:// — OpenCode answers 204 to a file:// url and
+        // then stores no message at all, silently losing the turn.
+        url: "data:image/png;base64,UE5H",
+      },
+    ]);
+    expect(bodies[1].parts).toEqual([{ type: "text", text: "no attachment" }]);
+    client.close();
+  });
+});

--- a/packages/sdk/src/OpenCodeClient.ts
+++ b/packages/sdk/src/OpenCodeClient.ts
@@ -9,6 +9,7 @@ import type {
   OpenCodePart,
   OpenCodeRawEvent,
   PermissionReply,
+  PromptFile,
   ProviderAuthMethod,
   ProviderCatalogEntry,
   ProviderInfo,
@@ -1090,6 +1091,7 @@ export class OpenCodeClient extends BaseAgentRuntime implements AgentRuntime {
     agent?: string,
     model?: string | null,
     variant?: string | null,
+    files?: PromptFile[],
   ): Promise<void> {
     const m = parseModel(model);
     const res = await this.fetchWithTimeout(
@@ -1098,7 +1100,18 @@ export class OpenCodeClient extends BaseAgentRuntime implements AgentRuntime {
         method: "POST",
         headers: this.headers(true),
         body: JSON.stringify({
-          parts: [{ type: "text", text }],
+          // Attachments ride as `file` parts so a vision model actually sees
+          // them; the text still names them, so the agent can also open the
+          // workspace copy with its own tools (#88).
+          parts: [
+            { type: "text", text },
+            ...(files ?? []).map((f) => ({
+              type: "file",
+              mime: f.mime,
+              filename: f.filename,
+              url: f.url,
+            })),
+          ],
           ...(agent ? { agent } : {}),
           ...(m ? { model: m } : {}),
           system: ARTIFACT_PRESENTATION_SYSTEM,

--- a/packages/sdk/src/acp/AcpRuntime.ts
+++ b/packages/sdk/src/acp/AcpRuntime.ts
@@ -34,6 +34,7 @@ import type {
   HistoryPart,
   PermissionAskedEvent,
   PermissionReply,
+  PromptFile,
   QuestionAskedEvent,
   SessionMeta,
   SessionPage,
@@ -591,6 +592,7 @@ export class AcpRuntime extends BaseAgentRuntime implements AgentRuntime {
     _agent?: string,
     _model?: string | null,
     _variant?: string | null,
+    _files?: PromptFile[],
   ): Promise<void> {
     const state = await this.ensureSession(sessionId);
     state.promptRunning = true;
@@ -599,6 +601,10 @@ export class AcpRuntime extends BaseAgentRuntime implements AgentRuntime {
     // approximated: ACP v1 has no per-turn agent, no `session/set_model`, and no
     // effort vocabulary. codex-acp folds effort INTO the model id, so honouring
     // `variant` would mean guessing another agent's id grammar.
+    // `files` is dropped for now too: ACP has image content blocks, but sending
+    // them requires honouring the agent's advertised `promptCapabilities.image`,
+    // and an agent that never claimed the capability would fail the whole turn.
+    // The attachment still reaches the workspace, and the text still names it.
     try {
       const result = await this.peer.request<AcpPromptResult>(
         "session/prompt",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -34,4 +34,5 @@ export {
   type PermissionAskedEvent,
   type PermissionResolvedEvent,
   type PermissionReply,
+  type PromptFile,
 } from "./types";

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -5,6 +5,7 @@ import type {
   OpenCodeEvent,
   PermissionAskedEvent,
   PermissionReply,
+  PromptFile,
   QuestionAskedEvent,
   RuntimeStatus,
   SessionMeta,
@@ -70,13 +71,16 @@ export interface AgentRuntime {
    *  turn to the current default, overriding a session's stale creation-time
    *  binding; omit to use the session/runtime default. `variant` picks a
    *  per-turn reasoning-effort level (a name from the model's `variants`); omit
-   *  for the model's default effort. See lib/runtime.ts. */
+   *  for the model's default effort. `files` sends attachments as real
+   *  multimodal parts so a vision model sees the image, not just its name (#88).
+   *  See lib/runtime.ts. */
   sendPrompt(
     sessionId: string,
     text: string,
     agent?: string,
     model?: string | null,
     variant?: string | null,
+    files?: PromptFile[],
   ): Promise<void>;
   abortSession(sessionId: string): Promise<void>;
   /** Revert the session to (and including) `messageID`, dropping it and every

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -296,6 +296,23 @@ export interface OpenCodeClientOptions {
   directory?: string;
 }
 
+/**
+ * A file sent as a real multimodal part of a turn, so a vision-capable model
+ * sees the image itself rather than a filename in the prose (#88).
+ *
+ * `url` MUST be a `data:` URL. OpenCode accepts a `file://` url and answers 204,
+ * then stores no message at all — the turn is silently lost — so the bytes ride
+ * in the request.
+ */
+export interface PromptFile {
+  /** Name shown to the model; the workspace file name it was read from. */
+  filename: string;
+  /** e.g. "image/png". */
+  mime: string;
+  /** `data:<mime>;base64,<…>`. */
+  url: string;
+}
+
 // ---- Provider / model configuration (OpenCode-native, one source of truth) ----
 
 export interface ProviderModelInfo {


### PR DESCRIPTION
Fixes #88.

## The bug

Attaching a PNG copied it into the workspace and named it in the prompt text:

```
inspect this figure

Files added to the workspace: pasted.png
```

…but the turn itself carried exactly one part:

```json
{ "parts": [{ "type": "text", "text": "…" }] }
```

So a vision-capable model never received the pixels. The reporter's model saying it could not inspect the figure was accurate, not a hallucination.

## The fix

Image attachments now also ride as OpenCode `file` parts:

```json
{ "parts": [
  { "type": "text", "text": "inspect this figure\n\nFiles added to the workspace: pasted.png" },
  { "type": "file", "mime": "image/png", "filename": "pasted.png", "url": "data:image/png;base64,…" }
] }
```

The text note stays deliberately — the agent can still open the workspace copy with its own tools, which is what you want for follow-up work on the file.

## Why `data:` and not `file://`

Probed against the pinned sidecar (1.18.12) before writing any code:

| `url` | POST | stored |
|---|---|---|
| `data:image/png;base64,…` | 204 | file part, mime and filename intact |
| `file:///abs/path.png` | 204 | **nothing — no message at all** |
| `path.png` (relative) | 204 | **nothing** |

A `file://` url is accepted and then silently drops the entire turn — no message, no error. So the bytes travel in the request, and `PromptFile` documents that constraint at the type.

## Scope

- **Images only** (`png`/`jpeg`/`gif`/`webp`). A CSV or notebook is better read by the agent's own tools than inlined into every request, and the note already points at it.
- **Never fails a send.** Unreadable, oversized (>12 MB — base64 inflates by 4/3 into a single JSON body), or non-image attachments are omitted, leaving today's note-only behavior.
- **Attachment reads happen inside the send**, not before it, so the echo and spinner still appear on click rather than after a multi-MB read.
- **No behavior change without attachments** — the body is byte-for-byte what it was, asserted in the new SDK test.
- **ACP drops `files` explicitly.** ACP has image content blocks, but sending them requires honouring the agent's advertised `promptCapabilities.image`, and an agent that never claimed it would fail the whole turn. Noted in code as separate work; attachments are a desktop-only feature and the OpenCode path is what #88 reports.

## Validation

- 6 new tests in `promptAttachments.test.ts` (data-URL part, non-image skipped, oversize skipped, one unreadable does not sink the others, browser no-op, no read when there are no attachments)
- New SDK wire test asserting the exact `parts` array, with and without attachments
- Full suite **935 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean

**Verified up to OpenCode storing the image part.** Whether the provider then relays it depends on the model — that last hop needs a manual check with a vision model, which I have a DMG building for.