### PR TITLE
fix(notebook): select a cell and insert above/below it

### DIFF
--- a/apps/desktop/src/components/notebook/NotebookEditor.cells.test.tsx
+++ b/apps/desktop/src/components/notebook/NotebookEditor.cells.test.tsx
@@ -1,0 +1,95 @@
+// Selecting a cell and inserting around it (#93): before this, the only way to
+// add a cell was the button at the bottom, which always appended to the END,
+// and no keyboard shortcut reached the notebook at all.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { NotebookEditor } from "./NotebookEditor";
+
+const NOTEBOOK = JSON.stringify({
+  cells: ["one", "two", "three"].map((s) => ({
+    cell_type: "code",
+    source: [s],
+    outputs: [],
+  })),
+  metadata: { kernelspec: { name: "python3", language: "python" } },
+  nbformat: 4,
+  nbformat_minor: 5,
+});
+
+vi.mock("@/lib/artifactFile", () => ({
+  readArtifact: async () => ({ encoding: "utf8", data: NOTEBOOK }),
+  writeWorkspaceFile: async () => {},
+}));
+vi.mock("@/components/inspector/ProvenancePanel", () => ({ ProvenancePanel: () => null }));
+
+const codeCells = () =>
+  screen.getAllByRole("textbox").map((el) => (el as HTMLTextAreaElement).value);
+
+async function open() {
+  render(<NotebookEditor path="analysis.ipynb" />);
+  await screen.findByLabelText("Cell 1");
+}
+
+describe("NotebookEditor · selecting a cell and inserting around it", () => {
+  it("inserts above the chosen cell, not at the end", async () => {
+    await open();
+    await userEvent.click(screen.getByLabelText("Insert cell above 2"));
+    expect(codeCells()).toEqual(["one", "", "two", "three"]);
+  });
+
+  it("inserts below the chosen cell, not at the end", async () => {
+    await open();
+    await userEvent.click(screen.getByLabelText("Insert cell below 1"));
+    expect(codeCells()).toEqual(["one", "", "two", "three"]);
+  });
+
+  it("renumbers so the [n] labels stay in reading order", async () => {
+    await open();
+    await userEvent.click(screen.getByLabelText("Insert cell above 1"));
+    // The new cell is [1] and everything below it shifted down by one.
+    expect(screen.getByLabelText("Cell 1")).toHaveValue("");
+    expect(screen.getByLabelText("Cell 4")).toHaveValue("three");
+  });
+
+  it("Esc then a/b inserts around the selected cell (Jupyter's command mode)", async () => {
+    await open();
+    await userEvent.click(screen.getByLabelText("Cell 2"));
+    await userEvent.keyboard("{Escape}");
+    await userEvent.keyboard("a");
+    expect(codeCells()).toEqual(["one", "", "two", "three"]);
+
+    // Still in command mode, so the next key drives the notebook too.
+    await userEvent.keyboard("b");
+    expect(codeCells()).toEqual(["one", "", "", "two", "three"]);
+  });
+
+  it("keeps typing into the cell while in edit mode ('a' is just an 'a')", async () => {
+    await open();
+    await userEvent.click(screen.getByLabelText("Cell 2"));
+    await userEvent.keyboard("ab");
+    // No cell was inserted — the keys were text. (Where they land depends on the
+    // caret, which a click sets from the click position.)
+    expect(codeCells()).toHaveLength(3);
+    expect((screen.getByLabelText("Cell 2") as HTMLTextAreaElement).value).toContain("ab");
+  });
+
+  it("moves the selection with j/k and Enter returns to editing", async () => {
+    await open();
+    await userEvent.click(screen.getByLabelText("Cell 1"));
+    await userEvent.keyboard("{Escape}");
+    await userEvent.keyboard("j"); // down to cell 2
+    await userEvent.keyboard("{Enter}"); // back into the text
+    await userEvent.keyboard("!");
+    expect(codeCells()).toEqual(["one", "two!", "three"]);
+  });
+
+  it("deleting a cell keeps a neighbour selected and renumbers", async () => {
+    await open();
+    await userEvent.click(screen.getByLabelText("Delete cell 2"));
+    expect(codeCells()).toEqual(["one", "three"]);
+    // The cell that slid into slot 2 is selected, so a/b act on it.
+    await userEvent.keyboard("a");
+    expect(codeCells()).toEqual(["one", "", "three"]);
+  });
+});

--- a/apps/desktop/src/components/notebook/NotebookEditor.tsx
+++ b/apps/desktop/src/components/notebook/NotebookEditor.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  ArrowDownToLine,
   ArrowLeft,
+  ArrowUpToLine,
   ExternalLink,
   History,
   Loader2,
@@ -72,6 +74,15 @@ export function NotebookEditor({
   // header button, offered wherever a notebook is viewed.
   const [jupyterInstalled, setJupyterInstalled] = useState(false);
   const [openingLab, setOpeningLab] = useState(false);
+  // The selected cell, and whether the keyboard is typing INTO it or driving it
+  // (Jupyter's edit vs command mode). Command mode is what makes "select a cell
+  // and press a/b" work at all — without it every key is just text (#93).
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [mode, setMode] = useState<"edit" | "command">("edit");
+  const cellRefs = useRef(new Map<number, HTMLDivElement | null>());
+  const codeRefs = useRef(new Map<number, HTMLTextAreaElement | null>());
+  /** Set when the keyboard put us into edit mode, so the caret lands at the end. */
+  const caretToEnd = useRef(false);
   const cellsRef = useRef<NotebookCell[] | null>(null);
   cellsRef.current = cells;
   const rawRef = useRef<string | null>(null);
@@ -240,16 +251,43 @@ export function NotebookEditor({
     }
   };
 
+  // `index` is both the cell's identity and the position shown as "[n]", and
+  // serialization follows array order — so every structural change renumbers.
+  // Without it, inserting in the middle would label cells [1] [4] [2].
+  const renumber = (list: NotebookCell[]) => list.map((c, i) => ({ ...c, index: i + 1 }));
+
   const addCell = () => {
+    const at = (cellsRef.current?.length ?? 0) + 1;
+    setCells((c) => renumber([...(c ?? []), { index: at, language, code: "" }]));
+    setActiveIndex(at);
+    setMode("edit");
+    setSaved(false);
+  };
+
+  /** Insert an empty cell beside `index`. `next` is the mode to land in: typing
+   *  after a button click, still driving after an `a`/`b` keystroke. */
+  const insertCell = (index: number, where: "above" | "below", next: "edit" | "command" = "edit") => {
     setCells((c) => {
-      const next = (c?.[c.length - 1]?.index ?? 0) + 1;
-      return [...(c ?? []), { index: next, language, code: "" }];
+      if (!c) return c;
+      const at = c.findIndex((cell) => cell.index === index);
+      if (at < 0) return c;
+      const list = [...c];
+      list.splice(where === "above" ? at : at + 1, 0, { index: 0, language, code: "" });
+      return renumber(list);
     });
+    // Renumbering means the new cell takes `index` itself when inserted above,
+    // and the slot after it when inserted below.
+    setActiveIndex(where === "above" ? index : index + 1);
+    setMode(next);
     setSaved(false);
   };
 
   const removeCell = (index: number) => {
-    setCells((c) => c?.filter((cell) => cell.index !== index) ?? null);
+    const remaining = (cellsRef.current?.length ?? 1) - 1;
+    setCells((c) => (c ? renumber(c.filter((cell) => cell.index !== index)) : null));
+    // Keep a cell selected: the one that slid into this slot, else the last.
+    setActiveIndex(remaining <= 0 ? null : Math.min(index, remaining));
+    setMode("command");
     setSaved(false);
   };
 
@@ -262,8 +300,72 @@ export function NotebookEditor({
     if ((e.metaKey || e.ctrlKey || e.shiftKey) && e.key === "Enter") {
       e.preventDefault();
       void run(cell);
+      return;
+    }
+    // Esc leaves the text and drives the cell instead — the same door into
+    // command mode Jupyter uses, and the only one that frees bare a/b/j/k.
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setActiveIndex(cell.index);
+      setMode("command");
     }
   };
+
+  /** Command mode: the cell is selected but not being typed into, so single
+   *  keys act on the notebook. Modified chords are left to the browser/OS. */
+  const onCellCommandKeyDown = (e: KeyboardEvent<HTMLDivElement>, cell: NotebookCell) => {
+    // Keys pressed in the textarea BUBBLE to this container, so without these
+    // guards typing "ab" in a cell would insert two cells instead of two
+    // characters. Only the container's own keys, and only in command mode.
+    if (e.target !== e.currentTarget || mode !== "command") return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const last = cells?.length ?? 1;
+    switch (e.key) {
+      case "Enter":
+        e.preventDefault();
+        caretToEnd.current = true;
+        setMode("edit");
+        break;
+      case "a":
+        e.preventDefault();
+        insertCell(cell.index, "above", "command");
+        break;
+      case "b":
+        e.preventDefault();
+        insertCell(cell.index, "below", "command");
+        break;
+      case "ArrowUp":
+      case "k":
+        if (cell.index > 1) {
+          e.preventDefault();
+          setActiveIndex(cell.index - 1);
+        }
+        break;
+      case "ArrowDown":
+      case "j":
+        if (cell.index < last) {
+          e.preventDefault();
+          setActiveIndex(cell.index + 1);
+        }
+        break;
+    }
+  };
+
+  // Put the caret where the selection now is. Runs only on a real selection or
+  // mode change, so it never steals focus from whatever else the user clicked.
+  useEffect(() => {
+    if (activeIndex === null) return;
+    if (mode === "command") {
+      cellRefs.current.get(activeIndex)?.focus();
+      return;
+    }
+    const code = codeRefs.current.get(activeIndex);
+    code?.focus();
+    // Only when edit mode was ENTERED by keyboard: Jupyter drops the caret at
+    // the end of the cell. A click must keep the caret where it was clicked.
+    if (caretToEnd.current && code) code.setSelectionRange(code.value.length, code.value.length);
+    caretToEnd.current = false;
+  }, [activeIndex, mode]);
 
   return (
     <div className="flex h-full flex-col">
@@ -359,7 +461,20 @@ export function NotebookEditor({
             </div>
           )}
           {cells?.map((cell) => (
-            <div key={cell.index} className="group mb-4">
+            <div
+              key={cell.index}
+              // Focusable so command mode has somewhere to live; not in the tab
+              // order, because Esc from the code is the way in (as in Jupyter).
+              ref={(el) => void cellRefs.current.set(cell.index, el)}
+              tabIndex={-1}
+              onKeyDown={(e) => onCellCommandKeyDown(e, cell)}
+              className={cn(
+                "group mb-4 rounded-input outline-none",
+                mode === "command" &&
+                  activeIndex === cell.index &&
+                  "ring-1 ring-accent ring-offset-2 ring-offset-bg",
+              )}
+            >
               <div className="mb-1 flex items-center gap-2 text-xs text-muted">
                 <span className="font-mono">[{cell.index}]</span>
                 <span>{cell.language}</span>
@@ -388,6 +503,20 @@ export function NotebookEditor({
                     </button>
                   ))}
                 <button
+                  className="hidden rounded px-1 py-0.5 hover:bg-surface-2 hover:text-text group-hover:block"
+                  aria-label={`Insert cell above ${cell.index}`}
+                  onClick={() => insertCell(cell.index, "above")}
+                >
+                  <ArrowUpToLine size={11} />
+                </button>
+                <button
+                  className="hidden rounded px-1 py-0.5 hover:bg-surface-2 hover:text-text group-hover:block"
+                  aria-label={`Insert cell below ${cell.index}`}
+                  onClick={() => insertCell(cell.index, "below")}
+                >
+                  <ArrowDownToLine size={11} />
+                </button>
+                <button
                   className="hidden rounded px-1 py-0.5 hover:bg-surface-2 hover:text-error group-hover:block"
                   aria-label={`Delete cell ${cell.index}`}
                   onClick={() => removeCell(cell.index)}
@@ -396,9 +525,15 @@ export function NotebookEditor({
                 </button>
               </div>
               <textarea
+                ref={(el) => void codeRefs.current.set(cell.index, el)}
                 value={cell.code}
                 onChange={(e) => update(cell.index, { code: e.target.value })}
                 onKeyDown={(e) => onCellKeyDown(e, cell)}
+                // Typing in a cell IS selecting it, however focus got here.
+                onFocus={() => {
+                  setActiveIndex(cell.index);
+                  setMode("edit");
+                }}
                 rows={Math.min(Math.max(cell.code.split("\n").length, 1), 14)}
                 spellCheck={false}
                 className={cn(


### PR DESCRIPTION
Fixes #93.

## The bug

Both halves of the report check out:

- `addCell` only ever did `[...cells, newCell]` — **append to the end**. There was no way to add a cell next to the one you were working on.
- There was no selected-cell concept at all, and the only key binding in the whole editor was Enter-to-run. Nothing a Jupyter user's fingers know did anything.

## The fix

Jupyter's edit/command split, scoped to what the issue asks for:

| | |
|---|---|
| `Esc` | leave the text, select the cell |
| `Enter` | back into the text, caret at the end (as Jupyter does) |
| `a` / `b` | insert above / below, staying in command mode so you can repeat |
| `j` / `k`, `↓` / `↑` | move the selection |

Plus **hover buttons on every cell for insert-above and insert-below**, because a shortcut nobody can discover is only half a fix — and a ring on the selected cell, so "which cell am I on" is visible.

## Two things worth a look in review

**Renumbering.** `index` is simultaneously a cell's identity, its React key, and the `[n]` shown to the user — and `serializeIpynb` writes cells in *array order*, ignoring `index`. So inserting in the middle without renumbering would label cells `[1] [4] [2]`. Every structural change now renumbers, which keeps the label honest.

**A bug the tests caught.** Keys pressed inside a textarea **bubble** to the cell container, so my first version acted on them regardless of mode — typing `ab` in a cell inserted two cells instead of two characters. The handler now ignores any event whose target is not the container itself, and `"keeps typing into the cell while in edit mode ('a' is just an 'a')"` is the regression guard.

## Checked, not assumed

`SessionView` has a window-level `Esc` handler that interrupts a running turn. It skips when `e.defaultPrevented`, and this handler calls `preventDefault()`, so entering command mode cannot cancel your run.

## Known limitation (pre-existing)

The insert buttons are `group-hover` gated, exactly like the existing Run and Delete buttons — so on touch they are as hard to reach as those already are. Not a regression, but if we want notebooks usable from the phone web client, that whole row needs a touch story. Happy to file it separately.

## Validation

- 7 new tests in `NotebookEditor.cells.test.tsx`: insert above / below not at the end, renumbering, Esc→a/b, typing stays typing, j/k + Enter, delete keeps a neighbour selected
- Full suite **942 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean; suite re-run 5× to confirm stability