### PR TITLE
fix(models): let a configured agent model actually run the turn

### DIFF
--- a/apps/desktop/src/components/settings/AgentModelsCard.tsx
+++ b/apps/desktop/src/components/settings/AgentModelsCard.tsx
@@ -140,6 +140,11 @@ export function AgentModelsCard({ providers }: { providers: ProviderInfo[] }) {
         <p className="text-[13px] text-muted">{t("agentModels.noModels")}</p>
       ) : (
         <div className="divide-y divide-faint">
+          {/* Which of these rows affect the messages the user actually sends,
+              and how a conversation's own pick relates to them (#85, #96). */}
+          <p className="pb-2 text-[12px] leading-relaxed text-muted">
+            {t("agentModels.primaryHint")}
+          </p>
           {rows.map((name) => {
             const variants = variantsFor(name);
             return (

--- a/apps/desktop/src/components/thread/ModelPicker.tsx
+++ b/apps/desktop/src/components/thread/ModelPicker.tsx
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Check, ChevronDown, ChevronRight, Cpu, Loader2, Search, Star, X, Zap } from "lucide-react";
-import { useRuntimeStore } from "@/lib/runtime";
+import { agentForTurn, useRuntimeStore } from "@/lib/runtime";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { cn } from "@/lib/cn";
 import {
@@ -214,17 +214,32 @@ export function ModelPicker({ sessionId }: { sessionId?: string } = {}) {
   const sessionVariants = useRuntimeStore((s) => s.sessionVariants);
   const setSessionModel = useRuntimeStore((s) => s.setSessionModel);
   const setSessionVariant = useRuntimeStore((s) => s.setSessionVariant);
+  const clearSessionModel = useRuntimeStore((s) => s.clearSessionModel);
+  const agentModels = useRuntimeStore((s) => s.agentModels);
+  const agentVariants = useRuntimeStore((s) => s.agentVariants);
+  // The agent this pane's next turn runs on ("build", or "plan" in plan mode).
+  const turnAgent = useRuntimeStore((s) => (sessionId ? agentForTurn(s, sessionId) : null));
   const switching = useRuntimeStore((s) => s.switching);
 
   // When bound to a session (a split pane), the picker sets THAT pane's model /
   // effort — no global sidecar config PATCH, so other panes are untouched.
   // Without a sessionId it drives the global default (unchanged behavior).
-  const model = sessionId ? (sessionModels[sessionId] ?? defaultModel) : defaultModel;
-  const variantChoice = sessionId
-    ? sessionVariants[sessionId] !== undefined
-      ? sessionVariants[sessionId]
-      : reasoningVariant
-    : reasoningVariant;
+  //
+  // The displayed model mirrors the SEND's precedence exactly (pane pick >
+  // configured agent model > global default). Showing the global default while
+  // a configured `build` model was what actually ran is the whole confusion in
+  // #85/#96 — the chip has to name the model the next turn will really use.
+  const pinnedModel = sessionId ? sessionModels[sessionId] : undefined;
+  const followedAgent = !pinnedModel && sessionId ? turnAgent : null;
+  const agentModel = followedAgent ? agentModels[followedAgent] : undefined;
+  const model = pinnedModel ?? agentModel ?? defaultModel;
+  const variantChoice = agentModel
+    ? (agentVariants[followedAgent!] ?? null)
+    : sessionId
+      ? sessionVariants[sessionId] !== undefined
+        ? sessionVariants[sessionId]
+        : reasoningVariant
+      : reasoningVariant;
   const pickModel = (key: string): Promise<void> | void =>
     sessionId ? setSessionModel(sessionId, key) : setDefaultModel(key);
   const pickVariant = (v: string | null) =>
@@ -362,6 +377,29 @@ export function ModelPicker({ sessionId }: { sessionId?: string } = {}) {
           </button>
         )}
       </div>
+
+      {/* Where this pane's model comes from. Rendered ONLY when it is not the
+          plain global default, so the common case stays uncluttered and the
+          surprising case (an agent setting is in force, or this conversation
+          was pinned away from it) is stated instead of left to be guessed. */}
+      {sessionId && (agentModel || (pinnedModel && turnAgent)) && (
+        <div className="flex shrink-0 items-center gap-2 border-b border-faint px-2.5 py-1.5">
+          {agentModel ? (
+            <span className="truncate text-[11px] text-muted">
+              {t("composer.model.followingAgent", { agent: followedAgent })}
+            </span>
+          ) : (
+            <button
+              className="truncate rounded px-1.5 py-0.5 text-[11px] text-accent hover:bg-accent/10"
+              onClick={() => clearSessionModel(sessionId)}
+            >
+              {agentModels[turnAgent!]
+                ? t("composer.model.followAgent", { agent: turnAgent })
+                : t("composer.model.useDefault")}
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Filter chips */}
       {options.length > 0 && (

--- a/apps/desktop/src/i18n/locales/de/session.json
+++ b/apps/desktop/src/i18n/locales/de/session.json
@@ -114,7 +114,10 @@
       "reasoning": "Denkaufwand",
       "reasoningDefault": "Modellstandard",
       "faster": "Schneller",
-      "smarter": "Klüger"
+      "smarter": "Klüger",
+      "followingAgent": "Folgt dem Agenten {{agent}}",
+      "followAgent": "Dem Agenten {{agent}} folgen",
+      "useDefault": "Globale Vorgabe verwenden"
     },
     "reference": {
       "filesAria": "Dateien im Arbeitsbereich",

--- a/apps/desktop/src/i18n/locales/de/settings.json
+++ b/apps/desktop/src/i18n/locales/de/settings.json
@@ -401,7 +401,8 @@
     "followDefaultNamed": "Standard ({{model}})",
     "modelFor": "Modell für {{agent}}",
     "defaultEffort": "Standardaufwand",
-    "effortFor": "Denkaufwand für {{agent}}"
+    "effortFor": "Denkaufwand für {{agent}}",
+    "primaryHint": "build und plan führen die Nachrichten aus, die du sendest. Ein hier gesetztes Modell gilt, sofern du nicht innerhalb einer Unterhaltung eines wählst — das gewinnt nur dort."
   },
   "ssh": {
     "title": "Bei {{host}} anmelden",

--- a/apps/desktop/src/i18n/locales/en/session.json
+++ b/apps/desktop/src/i18n/locales/en/session.json
@@ -114,7 +114,10 @@
       "reasoning": "Reasoning effort",
       "reasoningDefault": "Model default",
       "faster": "Faster",
-      "smarter": "Smarter"
+      "smarter": "Smarter",
+      "followingAgent": "Following the {{agent}} agent",
+      "followAgent": "Follow the {{agent}} agent",
+      "useDefault": "Use the global default"
     },
     "reference": {
       "filesAria": "Workspace files",

--- a/apps/desktop/src/i18n/locales/en/settings.json
+++ b/apps/desktop/src/i18n/locales/en/settings.json
@@ -401,7 +401,8 @@
     "followDefaultNamed": "Default ({{model}})",
     "modelFor": "Model for {{agent}}",
     "defaultEffort": "Default effort",
-    "effortFor": "Reasoning effort for {{agent}}"
+    "effortFor": "Reasoning effort for {{agent}}",
+    "primaryHint": "build and plan run the messages you send. A model set here applies unless you pick one inside a conversation, which wins for that conversation only."
   },
   "ssh": {
     "title": "Sign in to {{host}}",

--- a/apps/desktop/src/i18n/locales/es/session.json
+++ b/apps/desktop/src/i18n/locales/es/session.json
@@ -114,7 +114,10 @@
       "reasoning": "Esfuerzo de razonamiento",
       "reasoningDefault": "Predeterminado del modelo",
       "faster": "Más rápido",
-      "smarter": "Más inteligente"
+      "smarter": "Más inteligente",
+      "followingAgent": "Siguiendo al agente {{agent}}",
+      "followAgent": "Seguir al agente {{agent}}",
+      "useDefault": "Usar el modelo predeterminado global"
     },
     "reference": {
       "filesAria": "Archivos del espacio de trabajo",

--- a/apps/desktop/src/i18n/locales/es/settings.json
+++ b/apps/desktop/src/i18n/locales/es/settings.json
@@ -401,7 +401,8 @@
     "followDefaultNamed": "Predeterminado ({{model}})",
     "modelFor": "Modelo para {{agent}}",
     "defaultEffort": "Esfuerzo predeterminado",
-    "effortFor": "Esfuerzo de razonamiento para {{agent}}"
+    "effortFor": "Esfuerzo de razonamiento para {{agent}}",
+    "primaryHint": "build y plan ejecutan los mensajes que envías. El modelo definido aquí se aplica salvo que elijas uno dentro de una conversación, que prevalece solo en esa conversación."
   },
   "ssh": {
     "title": "Iniciar sesión en {{host}}",

--- a/apps/desktop/src/i18n/locales/fr/session.json
+++ b/apps/desktop/src/i18n/locales/fr/session.json
@@ -114,7 +114,10 @@
       "reasoning": "Effort de raisonnement",
       "reasoningDefault": "Défaut du modèle",
       "faster": "Plus rapide",
-      "smarter": "Plus intelligent"
+      "smarter": "Plus intelligent",
+      "followingAgent": "Suit l'agent {{agent}}",
+      "followAgent": "Suivre l'agent {{agent}}",
+      "useDefault": "Utiliser le modèle par défaut global"
     },
     "reference": {
       "filesAria": "Fichiers de l’espace de travail",

--- a/apps/desktop/src/i18n/locales/fr/settings.json
+++ b/apps/desktop/src/i18n/locales/fr/settings.json
@@ -401,7 +401,8 @@
     "followDefaultNamed": "Par défaut ({{model}})",
     "modelFor": "Modèle pour {{agent}}",
     "defaultEffort": "Effort par défaut",
-    "effortFor": "Effort de raisonnement pour {{agent}}"
+    "effortFor": "Effort de raisonnement pour {{agent}}",
+    "primaryHint": "build et plan exécutent les messages que vous envoyez. Le modèle défini ici s'applique, sauf si vous en choisissez un dans une conversation, qui l'emporte pour cette conversation uniquement."
   },
   "ssh": {
     "title": "Se connecter à {{host}}",

--- a/apps/desktop/src/i18n/locales/ja/session.json
+++ b/apps/desktop/src/i18n/locales/ja/session.json
@@ -114,7 +114,10 @@
       "reasoning": "推論の強度",
       "reasoningDefault": "モデルの既定",
       "faster": "高速",
-      "smarter": "高性能"
+      "smarter": "高性能",
+      "followingAgent": "{{agent}} エージェントの設定に従っています",
+      "followAgent": "{{agent}} エージェントの設定に従う",
+      "useDefault": "グローバル既定を使用"
     },
     "reference": {
       "filesAria": "ワークスペースのファイル",

--- a/apps/desktop/src/i18n/locales/ja/settings.json
+++ b/apps/desktop/src/i18n/locales/ja/settings.json
@@ -399,7 +399,8 @@
     "followDefaultNamed": "既定 ({{model}})",
     "modelFor": "{{agent}} のモデル",
     "defaultEffort": "既定の強度",
-    "effortFor": "{{agent}} の推論の強度"
+    "effortFor": "{{agent}} の推論の強度",
+    "primaryHint": "build と plan は送信したメッセージを実行します。ここで設定したモデルが適用されますが、会話内でモデルを選ぶとその会話でのみ優先されます。"
   },
   "ssh": {
     "title": "{{host}} にサインイン",

--- a/apps/desktop/src/i18n/locales/ko/session.json
+++ b/apps/desktop/src/i18n/locales/ko/session.json
@@ -114,7 +114,10 @@
       "reasoning": "추론 강도",
       "reasoningDefault": "모델 기본값",
       "faster": "더 빠르게",
-      "smarter": "더 똑똑하게"
+      "smarter": "더 똑똑하게",
+      "followingAgent": "{{agent}} 에이전트 설정을 따르는 중",
+      "followAgent": "{{agent}} 에이전트 설정 따르기",
+      "useDefault": "전역 기본값 사용"
     },
     "reference": {
       "filesAria": "작업 공간 파일",

--- a/apps/desktop/src/i18n/locales/ko/settings.json
+++ b/apps/desktop/src/i18n/locales/ko/settings.json
@@ -399,7 +399,8 @@
     "followDefaultNamed": "기본값 ({{model}})",
     "modelFor": "{{agent}}의 모델",
     "defaultEffort": "기본 강도",
-    "effortFor": "{{agent}}의 추론 강도"
+    "effortFor": "{{agent}}의 추론 강도",
+    "primaryHint": "build와 plan은 보낸 메시지를 실행합니다. 여기서 설정한 모델이 적용되며, 대화 안에서 모델을 고르면 그 대화에서만 우선합니다."
   },
   "ssh": {
     "title": "{{host}}에 로그인",

--- a/apps/desktop/src/i18n/locales/zh-Hans/session.json
+++ b/apps/desktop/src/i18n/locales/zh-Hans/session.json
@@ -114,7 +114,10 @@
       "reasoning": "推理强度",
       "reasoningDefault": "模型默认",
       "faster": "更快",
-      "smarter": "更强"
+      "smarter": "更强",
+      "followingAgent": "跟随 {{agent}} 智能体设置",
+      "followAgent": "跟随 {{agent}} 智能体设置",
+      "useDefault": "使用全局默认模型"
     },
     "reference": {
       "filesAria": "工作区文件",

--- a/apps/desktop/src/i18n/locales/zh-Hans/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-Hans/settings.json
@@ -399,7 +399,8 @@
     "followDefaultNamed": "默认（{{model}}）",
     "modelFor": "{{agent}} 使用的模型",
     "defaultEffort": "默认强度",
-    "effortFor": "{{agent}} 的思考强度"
+    "effortFor": "{{agent}} 的思考强度",
+    "primaryHint": "build 与 plan 负责运行你发出的消息。这里设定的模型会生效，除非你在某个会话内单独选择了模型——那个选择只对该会话生效。"
   },
   "ssh": {
     "title": "登录 {{host}}",

--- a/apps/desktop/src/lib/runtime.store.test.ts
+++ b/apps/desktop/src/lib/runtime.store.test.ts
@@ -2377,3 +2377,85 @@ describe("auto-review on turn completion", () => {
     expect(reviewCalls()[1]![0]).toBe("ses_review_2");
   });
 });
+
+// #96: an agent carrying its own configured model must actually get to use it.
+// The send used to pass an explicit per-turn model unconditionally, which
+// overrode exactly that setting — so the `build` row did nothing to the
+// messages you send, and Plan mode ignored its own model (#85).
+describe("per-agent model precedence", () => {
+  const withAgents = async (agentModels: Record<string, string>) => {
+    mocks.currentModel = "openai/gpt-5";
+    await useRuntimeStore.getState().loadCatalog();
+    useRuntimeStore.setState({
+      agents: [
+        { name: "build", description: "" },
+        { name: "plan", description: "" },
+      ],
+      agentModels,
+      agentVariants: {},
+      defaultModel: "openai/gpt-5",
+      // Start from a clean pane: a per-session model set by an earlier test
+      // grafts onto the session its first send creates, and `currentId` would
+      // then carry that pick into this one.
+      sessionModels: {},
+      sessionVariants: {},
+      sessionAgents: {},
+      currentId: null,
+    });
+  };
+  const lastSend = () => {
+    const calls = mocks.sendPromptFullSpy.mock.calls;
+    return calls[calls.length - 1]!;
+  };
+
+  it("sends no model when the build agent has one, so its setting is what runs", async () => {
+    await withAgents({ build: "anthropic/claude-opus-4-8" });
+    await useRuntimeStore.getState().sendPrompt("hi");
+    const [, , agent, model] = lastSend();
+    expect(agent).toBeUndefined();
+    expect(model).toBeNull();
+  });
+
+  it("still pins the default when no agent model is configured (#8 unchanged)", async () => {
+    await withAgents({});
+    await useRuntimeStore.getState().sendPrompt("hi");
+    expect(lastSend()[3]).toBe("openai/gpt-5");
+  });
+
+  it("a model picked in THIS conversation outranks the agent setting", async () => {
+    await withAgents({ build: "anthropic/claude-opus-4-8" });
+    useRuntimeStore.getState().setSessionModel(DRAFT_KEY, "openai/o3");
+    await useRuntimeStore.getState().sendPrompt("hi");
+    expect(lastSend()[3]).toBe("openai/o3");
+  });
+
+  it("clearing the pick hands the turn back to the agent setting", async () => {
+    await withAgents({ build: "anthropic/claude-opus-4-8" });
+    useRuntimeStore.getState().setSessionModel(DRAFT_KEY, "openai/o3");
+    useRuntimeStore.getState().clearSessionModel(DRAFT_KEY);
+    await useRuntimeStore.getState().sendPrompt("hi");
+    expect(lastSend()[3]).toBeNull();
+  });
+
+  it("plan mode follows the plan agent's model, not the build one", async () => {
+    await withAgents({ build: "anthropic/claude-opus-4-8" });
+    useRuntimeStore.setState({ sessionAgents: { [DRAFT_KEY]: "plan" } });
+    await useRuntimeStore.getState().sendPrompt("hi");
+    const [, , agent, model] = lastSend();
+    expect(agent).toBe("plan");
+    // `plan` has no configured model, so the default is still pinned…
+    expect(model).toBe("openai/gpt-5");
+
+    // …and once it does, the turn stops overriding it.
+    useRuntimeStore.setState({ agentModels: { build: "x/y", plan: "openai/o3" } });
+    await useRuntimeStore.getState().sendPrompt("hi again");
+    expect(lastSend()[3]).toBeNull();
+  });
+
+  it("infers nothing from a catalog without the agent (older sidecar)", async () => {
+    await withAgents({ build: "anthropic/claude-opus-4-8" });
+    useRuntimeStore.setState({ agents: [] });
+    await useRuntimeStore.getState().sendPrompt("hi");
+    expect(lastSend()[3]).toBe("openai/gpt-5");
+  });
+});

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -31,6 +31,8 @@ import {
   importProject as importProjectFolder,
   setProjectPinned as setProjectPinnedCmd,
   deleteProject as deleteProjectCmd,
+  getAgentModels,
+  getAgentVariants,
   getApprovalMode,
   installSkillMarkdown,
   isTauri,
@@ -175,6 +177,13 @@ interface RuntimeState {
   threads: Record<string, Thread>;
   skills: SkillInfo[];
   agents: AgentInfo[];
+  /** Per-agent model / reasoning effort from OpenCode's config (Settings →
+   *  Models → per agent). Consulted when a pane has no explicit pick, so a
+   *  configured agent model is what actually runs the turn (#96). */
+  agentModels: Record<string, string>;
+  agentVariants: Record<string, string>;
+  /** Re-read the per-agent config after Settings writes it. */
+  refreshAgentModels: () => Promise<void>;
   /** Slash commands the runtime can run ("/" palette): config commands,
    *  skills and MCP prompts, one merged list from GET /command. */
   commands: CommandInfo[];
@@ -239,6 +248,9 @@ interface RuntimeState {
   sessionVariants: Record<string, string | null>;
   /** Set a session's model (per-pane); no sidecar config PATCH / reconnect. */
   setSessionModel: (sessionId: string, model: string) => void;
+  /** Drop a pane's explicit pick so the turn follows the agent config / default
+   *  again — without this a session model could be changed but never undone. */
+  clearSessionModel: (sessionId: string) => void;
   /** Set a session's reasoning effort (per-pane). */
   setSessionVariant: (sessionId: string, variant: string | null) => void;
   // The pane/agent setters and turn actions below take an optional `sessionId`
@@ -1501,9 +1513,34 @@ function variantExposed(
     ?.models.find((mm) => mm.id === model.slice(i + 1));
   return m?.variants?.includes(variant) ? variant : undefined;
 }
+/** OpenCode's primary agent when the composer is not in plan mode. */
+export const PRIMARY_AGENT = "build";
+
+/**
+ * Which agent will actually run this pane's next turn, or null when the catalog
+ * has no such agent (an older or custom sidecar). Null means nothing may be
+ * inferred from a per-agent setting, so the caller keeps sending the model.
+ */
+export function agentForTurn(
+  state: Pick<RuntimeState, "sessionAgents" | "agents">,
+  key: string,
+): string | null {
+  const name = state.sessionAgents[key] === "plan" ? "plan" : PRIMARY_AGENT;
+  return state.agents.some((a) => a.name === name) ? name : null;
+}
+
 /** The model + reasoning effort for a session's turn: its own per-pane override
- *  if set, else the global default. Lets each split pane run a different model. */
+ *  if set, else a configured agent model (#96), else the global default. */
 function modelForSession(state: RuntimeState, key: string): { model: string | null; variant: string | undefined } {
+  // An agent carrying its own configured model OWNS the turn: sending an
+  // explicit per-turn model would override exactly that setting, which is why
+  // the `build` row used to do nothing and Plan mode ignored its own model
+  // (#96). Only a model picked in THIS conversation outranks it — the same rule
+  // the background reviewer already relied on by passing no model at all.
+  if (!state.sessionModels[key]) {
+    const agent = agentForTurn(state, key);
+    if (agent && state.agentModels[agent]) return { model: null, variant: undefined };
+  }
   const model = state.sessionModels[key] ?? state.defaultModel;
   const variant = variantExposed(
     state.providers,
@@ -1536,6 +1573,8 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
   threads: {},
   skills: [],
   agents: [],
+  agentModels: {},
+  agentVariants: {},
   commands: [],
   defaultModel: null,
   providers: [],
@@ -1606,6 +1645,18 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
       const sessionModels = { ...s.sessionModels, [sessionId]: model };
       saveRecord(SESSION_MODELS_KEY, sessionModels);
       return { sessionModels };
+    }),
+  clearSessionModel: (sessionId) =>
+    set((s) => {
+      if (!(sessionId in s.sessionModels)) return {};
+      const sessionModels = { ...s.sessionModels };
+      delete sessionModels[sessionId];
+      saveRecord(SESSION_MODELS_KEY, sessionModels);
+      // The effort was picked FOR that model, so it goes with it.
+      const sessionVariants = { ...s.sessionVariants };
+      delete sessionVariants[sessionId];
+      saveRecord(SESSION_VARIANTS_KEY, sessionVariants);
+      return { sessionModels, sessionVariants };
     }),
   setSessionVariant: (sessionId, variant) =>
     set((s) => {
@@ -1713,8 +1764,25 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
     set({ serverUrl, modelSwitchError: null });
   },
 
+  refreshAgentModels: async () => {
+    // Desktop-only config (the helpers answer {} in the browser). Never worth
+    // failing a connect over: an unreadable config just means "no overrides",
+    // and the send then keeps passing an explicit model, which is the old
+    // behavior rather than a broken one.
+    try {
+      const [agentModels, agentVariants] = await Promise.all([
+        getAgentModels(),
+        getAgentVariants(),
+      ]);
+      set({ agentModels, agentVariants });
+    } catch {
+      /* leave whatever we already had */
+    }
+  },
+
   loadCatalog: async () => {
     if (!client) return;
+    void get().refreshAgentModels();
     try {
       const [firstSkills, agents, defaultModel, commands, providers] = await Promise.all([
         client.listSkills(),


### PR DESCRIPTION
Fixes #96. Also resolves the confusion reported in #85.

## The bug

Every composer send passed an explicit per-turn model (`sessionModels[key] ?? defaultModel`), and an explicit per-turn model **overrides the agent's own configured model**. So:

- the `build` row in Settings → Models never affected the messages you send — it looked configurable and did nothing
- Plan mode sent `agent: "plan"` *and* a model, silently ignoring the model configured for `plan`

The background reviewer was the only path that got this right, and it says so in a comment — it passes no model precisely so the agent's config survives.

## Precedence, now explicit

```
a model picked in THIS conversation  >  the agent's configured model  >  the global default
```

When an agent carries its own model and the pane has no explicit pick, the turn sends **no** model and the agent's setting stands.

Two guards keep this from becoming a different bug:

- **Nothing is inferred from a catalog without the agent.** An older or custom sidecar with no `build` agent keeps today's behavior rather than silently dropping the model.
- **#8 still holds.** With no per-agent model configured, the default is still pinned per turn, so an old session does not revert to its stale creation-time model.

## The UI was the other half

This is what actually confused the reporter in #85: Settings said `gpt-5.6-terra`, the chat bar said `gpt-5.6-sol`, and neither was wrong on its own terms.

- **The chip now mirrors the send's precedence exactly**, so it can never advertise a model the turn will not use.
- **The popover states where the model comes from** — but only when it is not the plain global default, so the common case stays uncluttered and only the surprising case is explained.
- **A per-session pick can now be undone.** There was no way to clear one before: you could move a conversation off the default and never get back. The same row offers "Follow the build agent" or "Use the global default", whichever applies.
- **Settings says which agents run the messages you send** and how a conversation's own pick relates to them.

New strings are in all seven shipped locales (the repo's parity test enforces it).

## Validation

- 6 new store tests: agent model wins when unpinned; default still pinned when no agent model (#8); a conversation pick outranks the agent; clearing hands it back; plan mode follows `plan` not `build`; nothing inferred from a catalog missing the agent
- Full suite **948 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean
- DMG built for a UI pass: SHA-256 `765b74a9f202c0a982d3fda29fb988ff168f615e38558afa14aa2e42b350d462`

One thing worth noting in review: `refreshAgentModels` swallows its own failures. That is deliberate — an unreadable per-agent config must fall back to "no overrides", which is exactly the old behavior, not a broken send.