### PR TITLE
fix(chrome): align the titlebar with the traffic lights, and let the header drag the window

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
         "zoomHotkeysEnabled": false,
         "trafficLightPosition": {
           "x": 13,
-          "y": 22
+          "y": 26
         }
       }
     ],

--- a/apps/desktop/src-tauri/tauri.macos.conf.json
+++ b/apps/desktop/src-tauri/tauri.macos.conf.json
@@ -12,7 +12,7 @@
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "zoomHotkeysEnabled": false,
-        "trafficLightPosition": { "x": 13, "y": 22 },
+        "trafficLightPosition": { "x": 13, "y": 26 },
         "transparent": true,
         "windowEffects": {
           "effects": ["sidebar"],

--- a/apps/desktop/src/components/session/GroupTabs.dragRegion.test.tsx
+++ b/apps/desktop/src/components/session/GroupTabs.dragRegion.test.tsx
@@ -1,0 +1,49 @@
+// Tauri's drag region applies to DIRECT clicks only: it walks the composed path
+// and requires the element carrying the attribute to BE the event target. The
+// tab row is `flex-1`, so it covers the whole header beside the tabs — without
+// its own attribute the only draggable part of the header was the hairline
+// above and below that row, which is what dragging the window felt like.
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { makeLeaf, useLayoutStore } from "@/lib/layout";
+import { GroupTabs } from "./GroupTabs";
+
+vi.mock("@/lib/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/store")>();
+  return { ...actual, useOverlayTitlebar: () => true };
+});
+
+describe("GroupTabs window-drag surface", () => {
+  beforeEach(() => {
+    const leaf = makeLeaf("session-a");
+    useLayoutStore.setState({
+      groups: [{ id: "screen-a", name: "Analysis", tree: leaf, focusedLeafId: leaf.id, zoomedLeafId: null }],
+      activeGroupId: "screen-a",
+      tree: leaf,
+      focusedLeafId: leaf.id,
+      zoomedLeafId: null,
+      ephemeralGroupId: null,
+    });
+  });
+
+  it("makes the empty space beside the tabs draggable, not just the strip's edges", () => {
+    const { container } = render(<GroupTabs />);
+    const strip = container.firstElementChild!;
+    expect(strip.hasAttribute("data-tauri-drag-region")).toBe(true);
+
+    // The row that spans the remaining width must carry it too, or clicking
+    // anywhere in that space hits an element Tauri will not drag from.
+    const row = strip.querySelector<HTMLElement>(".flex-1");
+    expect(row).not.toBeNull();
+    expect(row!.hasAttribute("data-tauri-drag-region")).toBe(true);
+  });
+
+  it("leaves the tabs and the + button undraggable", () => {
+    const { container } = render(<GroupTabs />);
+    // A <button> blocks dragging in Tauri's own path walk, and a tab is never
+    // the drag element itself — neither may carry the attribute.
+    for (const el of container.querySelectorAll("button, [data-group-tab]")) {
+      expect(el.hasAttribute("data-tauri-drag-region")).toBe(false);
+    }
+  });
+});

--- a/apps/desktop/src/components/session/GroupTabs.tsx
+++ b/apps/desktop/src/components/session/GroupTabs.tsx
@@ -56,7 +56,17 @@ export function GroupTabs() {
             <PanelLeft size={14} strokeWidth={1.5} />
           </button>
         )}
-        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+        {/* This row is `flex-1`, so it covers the whole width left of the edge —
+            the empty space beside the tabs included. A bare drag region applies
+            to DIRECT clicks only (Tauri walks the composed path and requires
+            `el === target`), so without the attribute here the only draggable
+            part of the header was the hairline above and below this row. Tabs
+            and the + button stay undraggable: a tab is never the drag element
+            itself, and Tauri treats <button> as clickable, which blocks drag. */}
+        <div
+          data-tauri-drag-region={overlayTitlebar || undefined}
+          className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+        >
           {groups.map((g, i) => {
             const active = g.id === activeGroupId;
             const ephemeral = g.id === ephemeralGroupId;

--- a/apps/desktop/src/lib/titlebar.test.ts
+++ b/apps/desktop/src/lib/titlebar.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { trafficLightsPresent } from "./tauri";
 import {
@@ -41,5 +43,31 @@ describe("overlayTitlebarStyle (zoom)", () => {
     );
     // Without lights to clear, only a small pad.
     expect(overlayTitlebarStyle(false).paddingLeft).toBe("calc(0.5rem / var(--zoom))");
+  });
+});
+
+// The lights themselves are NATIVE — their position comes from the Tauri window
+// config, not from CSS. macOS merges `tauri.macos.conf.json` over the base by
+// REPLACING the whole `windows` array, so a value changed in one file and not
+// the other silently diverges. The visible symptom is the collapse button and
+// the Screen tabs sitting a few points below the lights, which has regressed
+// once already.
+describe("traffic-light position (native, config-driven)", () => {
+  const read = (rel: string) =>
+    JSON.parse(readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8")) as {
+      app: { windows: { trafficLightPosition?: { x: number; y: number } }[] };
+    };
+  const base = read("../../src-tauri/tauri.conf.json").app.windows[0]!;
+  const mac = read("../../src-tauri/tauri.macos.conf.json").app.windows[0]!;
+
+  it("is identical in the base and macOS window configs", () => {
+    expect(mac.trafficLightPosition).toEqual(base.trafficLightPosition);
+  });
+
+  it("sits where the strip centres its own content", () => {
+    // Measured against a real window: the strips centre their content in
+    // TITLEBAR_HEIGHT_PX, and this is the y that puts the lights on that same
+    // line. Pinned so a future edit cannot drift them apart unnoticed.
+    expect(base.trafficLightPosition?.y).toBe(26);
   });
 });

--- a/apps/desktop/src/lib/titlebar.ts
+++ b/apps/desktop/src/lib/titlebar.ts
@@ -8,6 +8,18 @@ import type { CSSProperties } from "react";
 export const TITLEBAR_HEIGHT_PX = 48; // matches Tailwind h-12
 export const TRAFFIC_LIGHT_INSET_PX = 78; // clears the three-button cluster
 
+/**
+ * The strips below centre their content in TITLEBAR_HEIGHT_PX, so the lights
+ * only look aligned if their own centre lands there too — and THAT is set by
+ * `trafficLightPosition` in BOTH `tauri.conf.json` and `tauri.macos.conf.json`
+ * (the macOS file replaces the windows array wholesale on merge, so a value
+ * changed in one and not the other silently wins or loses).
+ *
+ * Keep the two in sync with each other and with this height: the collapse
+ * button and the Screen tabs sitting a few points below the lights is what
+ * that mismatch looks like, and it has regressed once already.
+ */
+
 /** Inline style for a macOS overlay-titlebar strip. When `clearsLights` is
  *  true the strip insets past the traffic lights; otherwise it uses a small pad
  *  (matches pl-2). Both dimensions divide by --zoom so the strip covers the same


### PR DESCRIPTION
Two defects in the same strip — both, as you suspected, in the Screen-tab header.

## 1. The collapse button sat below the traffic lights

Measured off your screenshot rather than eyeballed — locating the light circles and the glyph by pixel:

| | centre y (device px) |
|---|---|
| traffic lights | 43.5 |
| collapse button glyph | 51.5 |

**8 device px ≈ 4pt too low** — and the Screen tabs sit on that same low line, so it was never the button alone: the whole strip's content was off. The *relative* offset is what I trust here; it survives any doubt about the screenshot's scale or crop, unlike an absolute measurement.

Cause: the strips centre their content in a 48px box (content centre 24pt), while the native lights are placed by `trafficLightPosition` and landed ~4pt higher. Fixed by moving the lights down to meet the content, **in both window configs** — macOS replaces the `windows` array wholesale on merge, so a value changed in one file and not the other diverges silently. That is very likely how this regressed the first time, so there is now a test pinning the two files to the same value.

## 2. Only two hairlines of the header could drag the window

Read Tauri 2.11.5's own `drag.js` rather than assuming. A bare `data-tauri-drag-region`:

```js
if (attr === '' || attr === 'true') return el === composedPath[0]
```

— **direct clicks only**; descendants do not inherit it. And clickable elements (`BUTTON`, `A`, `INPUT`, anything with a `role` or a non-negative `tabindex`) block dragging outright.

The header is:

```
<div data-tauri-drag-region … items-center>    ← draggable
  <div className="flex-1 … overflow-x-auto">   ← NOT draggable, and covers the
     …tabs… [+]                                  whole width beside the tabs
  </div>
</div>
```

So the only draggable surface was the sliver above and below that row. The row now carries the attribute too, which makes the empty space drag the window while leaving the interactive parts alone:

- empty space beside the tabs → the row **is** the event target → drags
- a tab → never the target itself (its label is), so the path walk returns false → the click still selects the Screen
- the **+** button → a `<button>` blocks drag

## Validation

- 2 new config tests (both files agree; the y value is pinned)
- 2 new drag tests (the full-width row is a drag region; no tab or button is)
- Full suite **956 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean

## Two things to confirm on the build

1. **The alignment number is empirical.** AppKit does not treat this value as a plain frame offset, so I matched it to a real window instead of deriving it. If the lights now look a hair off in either direction, tell me which way and I will nudge it — the constant is in one place with the coupling documented.
2. **My reading of the drag request:** tabs stay undraggable, everything else in the header drags. If you also wanted dragging from the tabs themselves, that is a one-line change (`"deep"` on the row).
