### PR TITLE
fix(chrome): read the traffic-light inset from the window config, not a copy

### DIFF
--- a/apps/desktop/src-tauri/src/macos.rs
+++ b/apps/desktop/src-tauri/src/macos.rs
@@ -1,10 +1,26 @@
 //! macOS-only window chrome fixes.
 
-use tauri::Window;
+use tauri::{Manager, Window};
 
-/// Keep in sync with `trafficLightPosition` in `tauri.macos.conf.json`.
+/// Fallback for a config with no `trafficLightPosition` at all. The real value
+/// is READ from the window config below — this used to be a hardcoded copy of
+/// it, which silently won over the JSON and drifted out of sync with it twice.
 const TRAFFIC_LIGHT_X: f64 = 13.0;
-const TRAFFIC_LIGHT_Y: f64 = 22.0;
+const TRAFFIC_LIGHT_Y: f64 = 26.0;
+
+/// The configured inset for `window`, from the SAME config the window was built
+/// from (on macOS that is `tauri.conf.json` merged with `tauri.macos.conf.json`).
+fn configured_inset(window: &Window) -> (f64, f64) {
+    window
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|w| w.label == window.label())
+        .and_then(|w| w.traffic_light_position.as_ref())
+        .map(|p| (p.x, p.y))
+        .unwrap_or((TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y))
+}
 
 /// Re-pin the traffic lights to the configured inset.
 ///
@@ -16,6 +32,7 @@ const TRAFFIC_LIGHT_Y: f64 = 22.0;
 /// (focus, resize, theme change), which cover launch, zoom and the in-app
 /// theme switch.
 pub fn reapply_traffic_light_inset(window: &Window) {
+    let (inset_x, inset_y) = configured_inset(window);
     let w = window.clone();
     // AppKit is main-thread-only; window events usually arrive there already.
     let _ = window.run_on_main_thread(move || unsafe {
@@ -35,10 +52,10 @@ pub fn reapply_traffic_light_inset(window: &Window) {
             return;
         };
         // Grow the (hidden) titlebar container so the buttons can sit
-        // TRAFFIC_LIGHT_Y below the window top, then walk the three buttons to
-        // TRAFFIC_LIGHT_X keeping their native spacing.
+        // `inset_y` below the window top, then walk the three buttons to
+        // `inset_x` keeping their native spacing.
         let close_rect = close.frame();
-        let titlebar_height = close_rect.size.height + TRAFFIC_LIGHT_Y;
+        let titlebar_height = close_rect.size.height + inset_y;
         let mut container_rect = container.frame();
         container_rect.size.height = titlebar_height;
         container_rect.origin.y = ns.frame().size.height - titlebar_height;
@@ -46,7 +63,7 @@ pub fn reapply_traffic_light_inset(window: &Window) {
         let spacing = mini.frame().origin.x - close_rect.origin.x;
         for (i, button) in [&*close, &*mini, &*zoom].into_iter().enumerate() {
             let mut rect = button.frame();
-            rect.origin.x = TRAFFIC_LIGHT_X + i as f64 * spacing;
+            rect.origin.x = inset_x + i as f64 * spacing;
             button.setFrameOrigin(rect.origin);
         }
     });


### PR DESCRIPTION
Follow-up to #101. The alignment half of that PR changed nothing on screen, and this is why.

## The value lives in three places, and the JSON is not the one that wins

`macos.rs` re-pins the lights on every focus / resize / theme event, from its **own hardcoded constant**:

```rust
/// Keep in sync with `trafficLightPosition` in `tauri.macos.conf.json`.
const TRAFFIC_LIGHT_X: f64 = 13.0;
const TRAFFIC_LIGHT_Y: f64 = 22.0;
```

That runs after the window is built, so it overwrites whatever the config said. #101 moved the number in both JSON files; this constant quietly moved it back on the next focus event.

It also explains why this keeps coming back. The same number sits in `tauri.conf.json`, `tauri.macos.conf.json` and `macos.rs`, and the copy that silently wins is the one least likely to be noticed — its own comment asked for exactly the discipline that had already failed twice.

## Fix

The re-pin now reads the inset from the window's own config:

```rust
fn configured_inset(window: &Window) -> (f64, f64) {
    window.config().app.windows.iter()
        .find(|w| w.label == window.label())
        .and_then(|w| w.traffic_light_position.as_ref())
        .map(|p| (p.x, p.y))
        .unwrap_or((TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y))
}
```

Tauri merges the macOS overlay into the baked config at build time, so this is the same value the window was created with. The constants survive only as a fallback for a config that sets no position at all.

With the override gone, the 26 from #101 finally applies.

## Why 26, restated on the safe argument

The reliable measurement was always the **relative** offset: the strip's content sat ~4pt below the lights' centre. In this code the buttons move linearly with the inset, so +4 closes a 4pt gap regardless of what the absolute baseline is — which is good, because the absolute figure depended on the screenshot's scale and crop, and the relative one does not.

## Validation

`cargo check` and `cargo clippy` clean; the JS suite is untouched (7 titlebar tests still pass, including the one from #101 pinning the two JSON files to the same value).

Needs a look on the packaged build — this cannot be seen in `pnpm dev`, since the re-pin only runs in the native window. If it is still off, the direction of the error now tells us the number to change, and there is finally only one number.
