### PR TITLE
feat(subagents): open a subagent into its own transcript

### DIFF
--- a/apps/desktop/src/components/thread/SubagentPane.test.tsx
+++ b/apps/desktop/src/components/thread/SubagentPane.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadBlock } from "@ai4s/shared";
 import { useRuntimeStore } from "@/lib/runtime";
@@ -12,7 +13,12 @@ function seed(blocks: Record<string, ThreadBlock[]>) {
   });
 }
 
-afterEach(() => useRuntimeStore.setState({ threads: {} }));
+afterEach(() => {
+  // Unmount BEFORE clearing the store: a still-mounted row subscribes to its
+  // child thread, and wiping it underneath produced an act() warning.
+  cleanup();
+  act(() => useRuntimeStore.setState({ threads: {} }));
+});
 
 describe("SubagentPane", () => {
   it("lists every subagent with its task and status, running and finished alike", () => {
@@ -51,6 +57,53 @@ describe("SubagentPane", () => {
     // A finished subagent keeps its elapsed time; the running one shows its step.
     expect(screen.getByText("12s")).toBeInTheDocument();
     expect(screen.getByText("reading results.csv")).toBeInTheDocument();
+  });
+
+  // The panel used to stop at "which subagent, on what, for how long" — the one
+  // thing you could not see was what the subagent actually DID.
+  it("opens a subagent into its own transcript, and only on request", async () => {
+    seed({
+      parent: [
+        {
+          kind: "tool-call",
+          tool: "task",
+          title: "Review the statistics",
+          status: "success",
+          childSessionId: "child-1",
+          startedAt: 1000,
+          endedAt: 5000,
+        },
+      ],
+      "child-1": [
+        { kind: "tool-call", tool: "bash", title: "python3 check.py", status: "success" },
+        { kind: "agent", markdown: "The residuals look fine." },
+      ],
+    });
+    render(<SubagentPane sessionId="parent" onClose={vi.fn()} />);
+
+    // Collapsed by default: a tool-heavy child thread is exactly the cost that
+    // must not be paid for every subagent at once (#92).
+    const row = screen.getByRole("button", { name: /Review the statistics/ });
+    expect(row).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("The residuals look fine.")).not.toBeInTheDocument();
+
+    await userEvent.click(row);
+    expect(row).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("The residuals look fine.")).toBeInTheDocument();
+    expect(screen.getByText("python3 check.py")).toBeInTheDocument();
+
+    await userEvent.click(row);
+    expect(screen.queryByText("The residuals look fine.")).not.toBeInTheDocument();
+  });
+
+  it("keeps a subagent that never started as a plain, unopenable row", () => {
+    seed({
+      parent: [{ kind: "tool-call", tool: "task", title: "Never ran", status: "pending" }],
+    });
+    render(<SubagentPane sessionId="parent" onClose={vi.fn()} />);
+
+    expect(screen.getByText("Never ran")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Never ran/ })).not.toBeInTheDocument();
   });
 
   it("says so plainly when the conversation has spawned none", () => {

--- a/apps/desktop/src/components/thread/SubagentPane.tsx
+++ b/apps/desktop/src/components/thread/SubagentPane.tsx
@@ -1,9 +1,11 @@
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Bot, CheckCircle2, CircleDashed, Loader2, X, XCircle } from "lucide-react";
+import { Bot, CheckCircle2, ChevronRight, CircleDashed, Loader2, X, XCircle } from "lucide-react";
 import type { ToolCallStatus } from "@ai4s/shared";
 import { cn } from "@/lib/cn";
 import { subagentActivity, useRuntimeStore } from "@/lib/runtime";
 import { PaneTitlebarInset } from "@/components/inspector/RightPane";
+import { BlockList } from "./BlockList";
 
 /** One subagent this conversation spawned. */
 interface Row {
@@ -28,6 +30,11 @@ function elapsed(row: Row, now: number): string {
  * as a collapsed tool row in the transcript: you cannot see which subagent is
  * running, on what, or how long it has been going. This panel lists them all —
  * finished ones included, so a finished run can still be reviewed.
+ *
+ * Each row opens into the subagent's OWN transcript. Collapsed by default and
+ * fetched on first open: a subagent's thread is usually tool-heavy, and
+ * mounting several of them at once is exactly the cost that made switching
+ * panes slow (#92).
  */
 export function SubagentPane({
   sessionId,
@@ -82,25 +89,73 @@ export function SubagentPane({
         ) : (
           <ul className="flex flex-col gap-1.5">
             {rows.map((row, i) => (
-              <li
-                key={`${row.childSessionId ?? "row"}:${i}`}
-                className="rounded-card border border-border bg-surface-2 px-2.5 py-2"
-              >
-                <div className="flex items-center gap-2">
-                  <StatusIcon status={row.status} />
-                  <span className="min-w-0 flex-1 truncate text-[13px] text-text">{row.task}</span>
-                  <span className="shrink-0 text-[11px] tabular-nums text-muted">
-                    {elapsed(row, now)}
-                  </span>
-                </div>
-                {row.childSessionId && row.status === "running" && (
-                  <Activity childId={row.childSessionId} />
-                )}
-              </li>
+              <SubagentRow key={`${row.childSessionId ?? "row"}:${i}`} row={row} now={now} />
             ))}
           </ul>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * One subagent: the summary line, and its full transcript once opened. A row
+ * without a child session (the task never started) stays a plain summary —
+ * there is nothing to open.
+ */
+function SubagentRow({ row, now }: { row: Row; now: number }) {
+  const [open, setOpen] = useState(false);
+  const childId = row.childSessionId;
+  return (
+    <li className="rounded-card border border-border bg-surface-2 px-2.5 py-2">
+      <div className="flex items-center gap-2">
+        <StatusIcon status={row.status} />
+        {childId ? (
+          <button
+            className="flex min-w-0 flex-1 items-center gap-1 text-left"
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+          >
+            <ChevronRight
+              size={12}
+              className={cn("shrink-0 text-muted transition-transform", open && "rotate-90")}
+            />
+            <span className="min-w-0 flex-1 truncate text-[13px] text-text">{row.task}</span>
+          </button>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-[13px] text-text">{row.task}</span>
+        )}
+        <span className="shrink-0 text-[11px] tabular-nums text-muted">{elapsed(row, now)}</span>
+      </div>
+      {/* The one-line "current step" is what the collapsed row can say; once the
+          transcript is open it would just repeat the last line of it. */}
+      {childId && row.status === "running" && !open && <Activity childId={childId} />}
+      {childId && open && <Transcript childId={childId} />}
+    </li>
+  );
+}
+
+/** The subagent's own thread, fetched on first open. `loadHistory` is session-
+ *  scoped, so it needs no workspace switch and is a no-op once loaded. */
+function Transcript({ childId }: { childId: string }) {
+  const thread = useRuntimeStore((s) => s.threads[childId]);
+  const loadHistory = useRuntimeStore((s) => s.loadHistory);
+  // Idempotent: it returns immediately once the thread is loaded, and a live
+  // subagent's blocks are already being folded in by the event stream.
+  useEffect(() => {
+    void loadHistory(childId);
+  }, [childId, loadHistory]);
+  const blocks = thread?.blocks;
+  if (!blocks?.length) {
+    return (
+      <div className="flex justify-center py-3">
+        <Loader2 size={13} className="animate-spin text-muted" />
+      </div>
+    );
+  }
+  return (
+    <div className="mt-1.5 border-t border-border pt-1.5 text-[12px]">
+      <BlockList blocks={blocks} />
     </div>
   );
 }


### PR DESCRIPTION
The subagent panel could tell you *which* subagent was running, on what, and for how long — but not what it actually did. A running one showed a single truncated line (the newest tool title); a finished one showed nothing at all, which is exactly the part worth reading.

## Change

Each row with a child session now opens into that subagent's full transcript, rendered by the same `BlockList` the main thread uses.

This turned out to be a rendering gap rather than a data one — all three pieces already existed:

- the child's thread lives in the same `threads` map (that is what the existing one-line activity indicator reads)
- `loadHistory` is **session-scoped**, so it needs no workspace switch and is a no-op once loaded
- `BlockList` already renders any blocks array

## Deliberate choices

- **Collapsed by default, fetched on first open.** A subagent's thread is usually tool-heavy, and mounting several at once is precisely the cost behind #92. Opening one is a decision the user makes.
- **The "current step" line now shows only while collapsed** — once the transcript is open it would just repeat its last line.
- **A task that never started** has no child session, so it stays a plain, unopenable row rather than a button that does nothing.

## Validation

- 2 new tests: a row opens and closes into its transcript and is collapsed by default; a never-started task exposes no button
- Fixed an `act()` warning the existing suite was already leaking (the store was cleared while a row was still subscribed)
- Full suite **964 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean