### PR TITLE
fix(ui): narrow-pane toolbar, sidebar icon weight, stray selection, window bounce

### DIFF
--- a/apps/desktop/src/app/routes/FilesPage.tsx
+++ b/apps/desktop/src/app/routes/FilesPage.tsx
@@ -327,7 +327,7 @@ export function SessionFilesPane({
   const crumbs = dir ? dir.split("/") : [];
   return (
     <div className="flex h-full flex-col">
-      <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
+      <div className="flex h-12 shrink-0 select-none items-center gap-2 border-b border-border px-4">
         <PaneTitlebarInset />
         <Folder size={14} strokeWidth={1.5} className="shrink-0 text-text" />
         <span className="truncate text-sm font-medium text-text" title={sessionDir ?? workspace ?? undefined}>

--- a/apps/desktop/src/app/routes/RunsPage.tsx
+++ b/apps/desktop/src/app/routes/RunsPage.tsx
@@ -173,7 +173,7 @@ function RunsView({ sessionId }: { sessionId?: string }) {
                 accent
               />
             ))}
-            <div className="flex shrink-0 items-center rounded-full border border-border bg-surface p-0.5 text-xs">
+            <div className="flex shrink-0 select-none items-center rounded-full border border-border bg-surface p-0.5 text-xs">
               {/* eslint-disable-next-line i18next/no-literal-string -- internal filter-window keys; "24h"/"7d"/"30d" are displayed verbatim as time-unit shorthand (consistent with existing convention, e.g. "eV"/"GB" units elsewhere), only "all" is display-translated via t("filter.anytime") */}
               {(["all", "24h", "7d", "30d"] as const).map((k) => {
                 const active = (filter.since ?? "all") === k;

--- a/apps/desktop/src/app/routes/SettingsPage.tsx
+++ b/apps/desktop/src/app/routes/SettingsPage.tsx
@@ -808,7 +808,10 @@ export function SettingsPage() {
     : [];
 
   return (
-    <div className="h-full overflow-y-auto">
+    // `select-none`: Settings is chrome, not a document. Right-clicking or
+    // dragging across a label used to leave stray highlight behind; the inputs
+    // opt back in globally (see index.css).
+    <div className="h-full select-none overflow-y-auto">
       {/* Modest top padding: the AppShell titlebar strip already clears 48px. */}
       <div className="mx-auto max-w-2xl px-4 pb-16 pt-4 sm:px-8">
         <h1 className="font-serif text-2xl text-text">{t(`nav.${section}`)}</h1>

--- a/apps/desktop/src/components/inspector/ArtifactInspector.tsx
+++ b/apps/desktop/src/components/inspector/ArtifactInspector.tsx
@@ -40,7 +40,7 @@ export function ArtifactInspector({
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
+      <header className="flex h-12 shrink-0 select-none items-center gap-2 border-b border-border px-4">
         <PaneTitlebarInset />
         <span className="truncate text-sm font-medium text-text">{data.title}</span>
         <div className="ml-2 flex items-center gap-1 text-text">

--- a/apps/desktop/src/components/inspector/FilePreviewInspector.tsx
+++ b/apps/desktop/src/components/inspector/FilePreviewInspector.tsx
@@ -221,7 +221,7 @@ export function FilePreviewInspector({
     <div className={cn("flex h-full flex-col", embedded && "overflow-hidden rounded-card border border-border bg-surface")}>
       <header
         className={cn(
-          "flex shrink-0 items-center border-b",
+          "flex shrink-0 select-none items-center border-b",
           embedded
             ? "h-10 gap-2 border-border px-3"
             : compactHeader

--- a/apps/desktop/src/components/inspector/NotebookInspector.tsx
+++ b/apps/desktop/src/components/inspector/NotebookInspector.tsx
@@ -65,7 +65,7 @@ export function NotebookInspector({
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
+      <header className="flex h-12 shrink-0 select-none items-center gap-2 border-b border-border px-4">
         <PaneTitlebarInset />
         <NotebookPen size={14} strokeWidth={1.5} className="text-text" />
         <span className="text-sm font-medium text-text">{t("notebook.title")}</span>

--- a/apps/desktop/src/components/inspector/PdfInspector.tsx
+++ b/apps/desktop/src/components/inspector/PdfInspector.tsx
@@ -22,7 +22,7 @@ export function PdfInspector({
   const onScroll = useScrollMemory(scrollRef, `pdf:${data.title}`);
   return (
     <div className="flex h-full flex-col">
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
+      <header className="flex h-12 shrink-0 select-none items-center gap-2 border-b border-border px-4">
         <PaneTitlebarInset />
         <span className="text-sm font-medium text-text">{data.title}</span>
         <div className="flex-1" />

--- a/apps/desktop/src/components/notebook/NotebookEditor.tsx
+++ b/apps/desktop/src/components/notebook/NotebookEditor.tsx
@@ -382,7 +382,7 @@ export function NotebookEditor({
     <div className="flex h-full flex-col">
       <div
         className={cn(
-          "flex shrink-0 items-center border-b",
+          "flex shrink-0 select-none items-center border-b",
           compactHeader
             ? "h-8 gap-1 border-faint px-2.5"
             : "h-12 gap-2 border-border px-4",

--- a/apps/desktop/src/components/session/SessionView.tsx
+++ b/apps/desktop/src/components/session/SessionView.tsx
@@ -394,7 +394,9 @@ export function SessionView({
           data-tauri-drag-region={asTitlebar || undefined}
           style={sidebarCollapsed && asTitlebar ? overlayTitlebarStyle(true) : undefined}
           className={cn(
-            "flex shrink-0 items-center border-faint",
+            // `select-none`: this row is chrome (title, zoom, panel toggles) —
+            // dragging across it used to leave stray highlight behind.
+            "flex shrink-0 select-none items-center border-faint",
             // Tiled panes get a compact header — h-12 wastes vertical space in
             // a small pane. Solo/web keeps the full-height titlebar row.
             solo ? "gap-2 px-6" : "gap-1 px-2.5",

--- a/apps/desktop/src/components/sidebar/Sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/Sidebar.tsx
@@ -1124,7 +1124,7 @@ function NavRow({
       onClick={onClick}
       className="flex items-center gap-2 rounded-input px-2 py-1 text-[13px] text-text hover:bg-surface-2"
     >
-      <span className="text-muted">{icon}</span>
+      <span className="text-text">{icon}</span>
       <span>{label}</span>
     </button>
   );

--- a/apps/desktop/src/components/thread/Composer.test.tsx
+++ b/apps/desktop/src/components/thread/Composer.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useUiStore } from "@/lib/store";
 import { resetParkedDrafts } from "@/lib/composerStash";
@@ -350,6 +350,57 @@ describe("agent mode switch (Build / Plan)", () => {
     );
     expect(container.firstElementChild?.className).toContain("border-link/60");
     expect(screen.getByLabelText("Agent mode").className).toContain("text-link");
+  });
+});
+
+// A narrow pane could not fit "Approve for me · Build · GPT-5.6 sol · High" as
+// words, so the toolbar wrapped and ate the composer's height.
+describe("Composer toolbar in a narrow pane", () => {
+  /** Drive the ResizeObserver the composer measures itself with. */
+  function withWidth(width: number) {
+    const observers: ((w: number) => void)[] = [];
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(private cb: (e: { contentRect: { width: number } }[]) => void) {
+          observers.push((w) => this.cb([{ contentRect: { width: w } }]));
+        }
+        observe() {
+          observers[observers.length - 1]!(width);
+        }
+        disconnect() {}
+      },
+    );
+  }
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("keeps the labels when there is room", () => {
+    withWidth(900);
+    render(<Composer onSend={vi.fn()} agentMode="build" onAgentModeChange={vi.fn()} />);
+    expect(screen.getByLabelText("Agent mode").textContent).toContain("Build");
+  });
+
+  it("drops the labels but keeps the control reachable when narrow", () => {
+    withWidth(320);
+    render(
+      <Composer
+        onSend={vi.fn()}
+        agentMode="build"
+        onAgentModeChange={vi.fn()}
+        approvalMode="approve"
+        onApprovalModeChange={vi.fn()}
+      />,
+    );
+    const agent = screen.getByLabelText("Agent mode");
+    const approval = screen.getByLabelText("Approval mode");
+    // The words are gone …
+    expect(agent.textContent).not.toContain("Build");
+    expect(approval.textContent).not.toContain("Approve for me");
+    // … but the buttons are still there, still named, and still work.
+    expect(agent).toBeInTheDocument();
+    fireEvent.click(agent);
+    expect(screen.getByRole("menuitemradio", { name: /Plan/ })).toBeInTheDocument();
   });
 });
 

--- a/apps/desktop/src/components/thread/Composer.tsx
+++ b/apps/desktop/src/components/thread/Composer.tsx
@@ -43,6 +43,9 @@ import { toast } from "@/lib/toast";
 import { cn } from "@/lib/cn";
 import { isGatewayWeb } from "@/lib/webMode";
 
+/** Composer width below which the toolbar shows icons without their labels. */
+const TOOLBAR_LABEL_MIN_PX = 440;
+
 /** A paste longer than this becomes a workspace file chip instead of raw text. */
 const PASTE_AS_FILE_CHARS = 2000;
 const PASTE_AS_FILE_LINES = 25;
@@ -259,6 +262,22 @@ export function Composer({
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
   }, [agentOpen]);
+  // A narrow pane cannot fit "Approve for me · Build · GPT-5.6 sol · High" as
+  // words — the row wrapped and ate the composer's height. Below this width the
+  // toolbar keeps the icons and drops the labels; every one of those buttons
+  // already carries an aria-label and a title, so nothing becomes unreachable.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [compactToolbar, setCompactToolbar] = useState(false);
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(([entry]) => {
+      setCompactToolbar((entry?.contentRect.width ?? 0) < TOOLBAR_LABEL_MIN_PX);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   const taRef = useRef<HTMLTextAreaElement>(null);
   // Caret position, tracked so an "@"/"#" being typed can be recognized in
   // place — mid-sentence references matter as much as ones at the start.
@@ -707,6 +726,7 @@ export function Composer({
 
   return (
     <div
+      ref={rootRef}
       className={cn(
         "relative rounded-card border bg-surface px-2 py-2 shadow-card",
         // Plan mode gets the blue link tone — distinct from shell (warn) and
@@ -972,7 +992,7 @@ export function Composer({
               onClick={() => setAgentOpen((o) => !o)}
             >
               {agentMode === "plan" ? <ClipboardList size={12} /> : <Hammer size={12} />}
-              <span>{agentCopy[agentMode].label}</span>
+              {!compactToolbar && <span>{agentCopy[agentMode].label}</span>}
               <ChevronDown size={11} />
             </button>
           </div>
@@ -1022,7 +1042,7 @@ export function Composer({
               onClick={() => setApprovalOpen((o) => !o)}
             >
               {approvalMode === "full" ? <Zap size={12} /> : <Hand size={12} />}
-              <span>{approvalCopy[approvalMode].label}</span>
+              {!compactToolbar && <span>{approvalCopy[approvalMode].label}</span>}
               <ChevronDown size={11} />
             </button>
           </div>
@@ -1030,7 +1050,7 @@ export function Composer({
         {/* Model picker + send kept together, pushed right (and wrapping as a
             unit) so the send button is always reachable on a narrow pane. */}
         <div className="ml-auto flex min-w-0 items-center gap-1.5">
-          {showModelPicker && <ModelPicker sessionId={modelSessionId} />}
+          {showModelPicker && <ModelPicker sessionId={modelSessionId} compact={compactToolbar} />}
           {configOptions && onConfigOption && (
             <AcpConfigPicker options={configOptions} onChange={onConfigOption} disabled={working} />
           )}

--- a/apps/desktop/src/components/thread/ModelPicker.tsx
+++ b/apps/desktop/src/components/thread/ModelPicker.tsx
@@ -200,7 +200,15 @@ function ReasoningSlider({
  * One picker body renders in two shells: an anchored popover on desktop/wide
  * web, a bottom sheet on phone-width viewports (`useIsMobile`).
  */
-export function ModelPicker({ sessionId }: { sessionId?: string } = {}) {
+export function ModelPicker({
+  sessionId,
+  compact,
+}: {
+  sessionId?: string;
+  /** Narrow composer: show the chip as an icon only. The button keeps its
+   *  aria-label and title, so the model stays discoverable without the words. */
+  compact?: boolean;
+} = {}) {
   const { t } = useTranslation(["session", "common"]);
   const navigate = useNavigate();
   const isMobile = useIsMobile();
@@ -542,8 +550,8 @@ export function ModelPicker({ sessionId }: { sessionId?: string } = {}) {
         ) : (
           <Cpu size={12} className="shrink-0" />
         )}
-        <span className="truncate text-text">{chipLabel}</span>
-        {activeVariant && (
+        {!compact && <span className="truncate text-text">{chipLabel}</span>}
+        {!compact && activeVariant && (
           <span className="shrink-0 text-muted">· {labelVariant(activeVariant)}</span>
         )}
         <ChevronDown size={11} className="shrink-0" />

--- a/apps/desktop/src/components/thread/SubagentPane.tsx
+++ b/apps/desktop/src/components/thread/SubagentPane.tsx
@@ -66,7 +66,7 @@ export function SubagentPane({
 
   return (
     <div className="flex h-full flex-col border-l border-border bg-surface">
-      <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
+      <div className="flex h-12 shrink-0 select-none items-center gap-2 border-b border-border px-4">
         <PaneTitlebarInset />
         <Bot size={14} strokeWidth={1.5} className="shrink-0 text-text" />
         <span className="text-sm font-medium text-text">{t("subagents.title")}</span>

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -149,6 +149,25 @@ body,
   height: 100%;
 }
 
+/* This is app chrome, not a document: the window itself must never scroll or
+   rubber-band. Without this, dragging anywhere — including the sidebar, the
+   Screen tabs and a pane header, none of which scroll — bounced the whole
+   window a few points and sprang back, so fixed furniture did not feel fixed. */
+html,
+body {
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+/* A real scroller reaching its end must not hand the leftover gesture to its
+   ancestors (which is what made the window bounce from inside a list). Keyed to
+   the utility classes the app actually scrolls with. */
+.overflow-y-auto,
+.overflow-auto,
+.overflow-x-auto {
+  overscroll-behavior: contain;
+}
+
 body {
   margin: 0;
   background: var(--bg);
@@ -156,6 +175,14 @@ body {
   font-family: Inter, system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+}
+
+/* Sidebar icon weight. lucide ships stroke-width 2, which next to the 1.5 of the
+   collapse button read thick and slightly fuzzy at these sizes. One rule instead
+   of a prop on every call site, so an icon added later matches by default.
+   (A CSS stroke-width beats the presentation attribute lucide sets inline.) */
+.sidebar-surface svg {
+  stroke-width: 1.5;
 }
 
 /* Sidebar background. With window vibrancy (macOS desktop app, data-vibrancy


### PR DESCRIPTION
Four pieces of chrome polish, from a round of UI review.

## 1. The composer toolbar wrapped in a narrow pane

"Approve for me", "Build" and the model name cannot sit side by side once a pane is tiled, so the row wrapped and ate the composer's own height.

Below **440px** the toolbar keeps its icons and drops the words — approval mode, agent mode, and the model chip (which also drops its effort suffix). Every one of those buttons already carries an `aria-label` and a `title`, so nothing becomes unreachable; the menus still open and still work.

Measured with a `ResizeObserver` on the composer itself rather than a viewport breakpoint, because what matters is the *pane's* width, not the window's.

## 2. Sidebar icons read thick and fuzzy

lucide ships `stroke-width: 2`, which sat badly next to the `1.5` collapse button directly above them.

Done as one rule scoped to the sidebar rather than a prop on every call site — so the folder and chevron icons in the project tree match too, and anything added later inherits it by default. (A CSS `stroke-width` overrides the presentation attribute lucide sets inline.)

The nav icons also move from `text-muted` to `text-text`, which is what actually made them look washed out.

## 3. Chrome was selectable

Settings, the pane header row (title, zoom, panel toggles) and every inspector panel header now opt out of selection, the way the sidebar and Screen tabs already did.

Safe by construction: `input`, `textarea` and `[contenteditable]` opt back **in** globally, so this cannot make a field unselectable. I deliberately did not flip the whole body to `user-select: none` — nothing currently marks message text as selectable, so a global opt-out would have silently broken copying an answer.

## 4. The window rubber-banded

Scrolling to either end bounced the entire window — sidebar, Screen tabs and pane headers included, none of which scroll — then sprang back. Fixed furniture did not feel fixed.

This is app chrome, not a document, so:

- the window itself no longer scrolls or overscrolls
- a real scroller reaching its end no longer hands the leftover gesture to its ancestors, which is what let a bounce start from *inside* a list

## Validation

- 2 new tests: labels present at full width; at narrow width the words are gone but the button is still named, still present, and its menu still opens
- Full suite **966 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean

Items 2–4 are visual and need a look on the build; item 1 is covered by tests but worth resizing a pane to feel.
