### PR TITLE
fix(review): take the reviewer off the task tool's delegation menu

### DIFF
--- a/apps/desktop/src/lib/autoReview.test.ts
+++ b/apps/desktop/src/lib/autoReview.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   autoReviewPrompt,
@@ -65,5 +67,26 @@ describe("autoReviewPrompt", () => {
     expect(prompt).toContain("- analysis.py\n- report.md");
     expect(prompt).toContain("checkpoint only");
     expect(prompt).toContain("absent Git HEAD");
+  });
+});
+
+// The reviewer is deployed into the OpenCode profile as a real agent. `mode`
+// decides who may invoke it: `all` also puts it on the task tool's delegation
+// menu, so a model could spawn it by itself and reviews turned up inside
+// subagents even with auto-review switched off. The app pins it as the agent of
+// its own background session — the primary role — so `primary` is what keeps
+// the feature working without handing it to the model.
+describe("the reviewer agent's profile", () => {
+  it("is not offered to the task tool", () => {
+    // vitest runs from apps/desktop; the profile lives at the repo root.
+    const md = readFileSync(
+      resolve(process.cwd(), "../../runtime/opencode-profile/agent/reviewer.md"),
+      "utf8",
+    );
+    const frontmatter = md.split("---")[1] ?? "";
+    const mode = /^mode:\s*(\S+)/m.exec(frontmatter)?.[1];
+    expect(mode).toBe("primary");
+    // It also may not spawn tasks of its own — a review that delegates is a loop.
+    expect(frontmatter).toMatch(/task:\s*deny/);
   });
 });

--- a/runtime/opencode-profile/agent/reviewer.md
+++ b/runtime/opencode-profile/agent/reviewer.md
@@ -1,6 +1,12 @@
 ---
 description: Reviews finished work in the workspace for scientific rigour — traceability, statistics, units, provenance and reproducibility — and reports findings without changing anything.
-mode: all
+# `primary`, deliberately NOT `all`: `all` also offers this agent to the task
+# tool, so a model could delegate to it on its own and reviews then appeared
+# inside subagents even with auto-review switched off. The app's auto-review
+# pins it as the agent of its own background session, which is the primary
+# role — so this keeps that working while taking it off the delegation menu.
+# Reviewing a subagent is a separate feature, to be designed as one.
+mode: primary
 temperature: 0.1
 permission:
   edit: deny


### PR DESCRIPTION
Reported: reviews appear inside subagents even with auto-review switched **off**.

## Not the app's gate

`shouldAutoReview` already refuses on both counts:

```ts
gate.enabled && gate.changedFiles && gate.hasReviewer && !gate.wasReview && !gate.isSubagent
```

So the app was never starting these.

## The actual route

The reviewer ships as a real agent in the OpenCode profile, with `mode: all`. Verified against the pinned sidecar that `mode` is a `primary` / `subagent` distinction — `general`, `explore` and `oracle` report `subagent`, `title` and `summary` report `primary`.

`all` means **both**. An agent that is subagent-capable is offered to the **task tool**, so the model can delegate to the reviewer whenever it likes — no app code involved, and the user's setting never consulted. That is the review appearing inside subagents.

## Fix

`mode: primary`.

The app's auto-review is unaffected: it creates its own background session and pins the reviewer as **that session's agent**, which is the primary role, not a delegation. `listAgents` still reports it, so the `hasReviewer` gate still passes.

A test pins the profile so this cannot silently regress, and also asserts the reviewer still denies `task` — a review that can delegate is a loop.

## On the follow-up

Reviewing a subagent's work is a reasonable thing to want. It should be designed as a feature, with its own trigger and its own place to appear — not inherited because an agent happened to be delegatable.

## Validation

Full suite **969 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean.

Worth confirming on the build that a normal multi-agent turn no longer produces reviewer subagents.