### PR TITLE
fix(interaction): always let the user answer a question in their own words

### DIFF
--- a/apps/desktop/src/components/thread/InteractionPrompt.test.tsx
+++ b/apps/desktop/src/components/thread/InteractionPrompt.test.tsx
@@ -47,6 +47,53 @@ describe("InteractionPrompt — question", () => {
     expect(onAnswer).toHaveBeenCalledWith("que_2", [["atlas.csv", "export.csv"]]);
   });
 
+  // A model that offers an "Other" option but forgets `custom` used to leave
+  // nowhere to say WHAT — and in quick-pick it answered the whole question with
+  // the bare word. Every question can now be answered in the user's own words.
+  it("always offers an own-words answer, even when the model did not ask for one", async () => {
+    const onAnswer = vi.fn();
+    render(<InteractionPrompt question={singleQ} onAnswer={onAnswer} onReject={noop} onPermission={noop} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Something else/ }));
+    // Revealing the field ends quick-pick: there is something to type first.
+    expect(onAnswer).not.toHaveBeenCalled();
+
+    await userEvent.type(screen.getByPlaceholderText(/type your own answer/i), "the parquet one");
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    // The typed text is the answer — not the label of the row that revealed it.
+    expect(onAnswer).toHaveBeenCalledWith("que_1", [["the parquet one"]]);
+  });
+
+  it("does not submit an empty own-words answer", async () => {
+    const onAnswer = vi.fn();
+    render(<InteractionPrompt question={singleQ} onAnswer={onAnswer} onReject={noop} onPermission={noop} />);
+    await userEvent.click(screen.getByRole("button", { name: /Something else/ }));
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("own words replace the pick on a single-select question", async () => {
+    const onAnswer = vi.fn();
+    render(<InteractionPrompt question={multiQ} onAnswer={onAnswer} onReject={noop} onPermission={noop} />);
+    // multi-select keeps its picks alongside the typed text
+    await userEvent.click(screen.getByText("atlas.csv"));
+    await userEvent.click(screen.getByRole("button", { name: /Something else/ }));
+    await userEvent.type(screen.getByPlaceholderText(/type your own answer/i), "and a third");
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    expect(onAnswer).toHaveBeenCalledWith("que_2", [["atlas.csv", "and a third"]]);
+  });
+
+  it("shows the field outright when the model did ask for free text", () => {
+    const customQ: QuestionAskedEvent = {
+      ...singleQ,
+      requestId: "que_3",
+      questions: [{ ...singleQ.questions[0], custom: true }],
+    };
+    render(<InteractionPrompt question={customQ} onAnswer={noop} onReject={noop} onPermission={noop} />);
+    expect(screen.getByPlaceholderText(/type your own answer/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Something else/ })).not.toBeInTheDocument();
+  });
+
   it("skips a question via reject", async () => {
     const onReject = vi.fn();
     render(<InteractionPrompt question={singleQ} onAnswer={noop} onReject={onReject} onPermission={noop} />);

--- a/apps/desktop/src/components/thread/InteractionPrompt.tsx
+++ b/apps/desktop/src/components/thread/InteractionPrompt.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Check, HelpCircle, ShieldQuestion } from "lucide-react";
+import { Check, HelpCircle, Pencil, ShieldQuestion } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { PermissionAskedEvent, PermissionReply, QuestionAskedEvent } from "@ai4s/sdk";
 import { cn } from "@/lib/cn";
@@ -68,6 +68,11 @@ function QuestionCard({
   // One selection set + one custom string per question.
   const [selected, setSelected] = useState<Record<number, Set<string>>>({});
   const [custom, setCustom] = useState<Record<number, string>>({});
+  // Which questions have their own-words field open. Every question can always
+  // be answered in the user's own words: a model that offers an "Other" option
+  // but forgets `custom` used to leave nowhere to say WHAT — and in quick-pick
+  // that answered the whole question with the bare word "Other".
+  const [ownWords, setOwnWords] = useState<Record<number, boolean>>({});
 
   const items = question.questions;
   const toggle = (qi: number, label: string, multiple: boolean) =>
@@ -78,15 +83,27 @@ function QuestionCard({
       return { ...s, [qi]: cur };
     });
 
+  /** Open the own-words field. Single-select questions drop their pick, the way
+   *  choosing any other option would. */
+  const openOwnWords = (qi: number, multiple: boolean) => {
+    setOwnWords((o) => ({ ...o, [qi]: true }));
+    if (!multiple) setSelected((s) => ({ ...s, [qi]: new Set() }));
+  };
+
   const answerFor = (qi: number): string[] => {
     const picked = [...(selected[qi] ?? [])];
     const c = custom[qi]?.trim();
+    // The typed text IS the answer — never the label of the row that revealed
+    // the field, which would tell the agent nothing.
     return c ? [...picked, c] : picked;
   };
   const ready = items.every((_, qi) => answerFor(qi).length > 0);
 
-  // Single question, single-select, no custom: click an option to answer at once.
-  const isQuickPick = items.length === 1 && !items[0].multiple && !items[0].custom;
+  // Single question, single-select, no free text yet: click an option to answer
+  // at once. Opening the own-words field ends quick-pick — there is now
+  // something to type and a Send to press.
+  const isQuickPick =
+    items.length === 1 && !items[0].multiple && !items[0].custom && !ownWords[0];
 
   return (
     <div className="rounded-card border border-accent/40 bg-surface shadow-card">
@@ -149,9 +166,24 @@ function QuestionCard({
                     </button>
                   );
                 })}
+                {/* The guaranteed escape hatch. Hidden behind a row so a
+                    question with good options stays a clean list, but always
+                    one click away — the agent asking cannot take it away by
+                    forgetting a flag. Skipped when it already asked for free
+                    text, which shows the field outright. */}
+                {!it.custom && !ownWords[qi] && (
+                  <button
+                    onClick={() => openOwnWords(qi, multiple)}
+                    className="flex items-center gap-2.5 rounded-input border border-dashed border-border px-3 py-2 text-left text-[13px] text-muted transition-colors hover:bg-surface-2 hover:text-text"
+                  >
+                    <Pencil size={13} className="shrink-0" />
+                    {t("interaction.question.other")}
+                  </button>
+                )}
               </div>
-              {it.custom && (
+              {(it.custom || ownWords[qi]) && (
                 <input
+                  autoFocus={!!ownWords[qi]}
                   value={custom[qi] ?? ""}
                   onChange={(e) => setCustom((c) => ({ ...c, [qi]: e.target.value }))}
                   placeholder={t("interaction.question.customPlaceholder")}

--- a/apps/desktop/src/i18n/locales/de/session.json
+++ b/apps/desktop/src/i18n/locales/de/session.json
@@ -293,7 +293,8 @@
   "interaction": {
     "question": {
       "heading": "Der Agent benötigt Ihre Eingabe",
-      "customPlaceholder": "Oder geben Sie Ihre eigene Antwort ein…"
+      "customPlaceholder": "Oder geben Sie Ihre eigene Antwort ein…",
+      "other": "Etwas anderes…"
     },
     "permission": {
       "heading": "Der Agent bittet um Erlaubnis:"

--- a/apps/desktop/src/i18n/locales/en/session.json
+++ b/apps/desktop/src/i18n/locales/en/session.json
@@ -293,7 +293,8 @@
   "interaction": {
     "question": {
       "heading": "The agent needs your input",
-      "customPlaceholder": "Or type your own answer…"
+      "customPlaceholder": "Or type your own answer…",
+      "other": "Something else…"
     },
     "permission": {
       "heading": "The agent asks permission:"

--- a/apps/desktop/src/i18n/locales/es/session.json
+++ b/apps/desktop/src/i18n/locales/es/session.json
@@ -293,7 +293,8 @@
   "interaction": {
     "question": {
       "heading": "El agente necesita tu opinión",
-      "customPlaceholder": "O escribe tu propia respuesta…"
+      "customPlaceholder": "O escribe tu propia respuesta…",
+      "other": "Otra cosa…"
     },
     "permission": {
       "heading": "El agente solicita permiso:"

--- a/apps/desktop/src/i18n/locales/fr/session.json
+++ b/apps/desktop/src/i18n/locales/fr/session.json
@@ -293,7 +293,8 @@
   "interaction": {
     "question": {
       "heading": "L'agent a besoin de votre réponse",
-      "customPlaceholder": "Ou saisissez votre propre réponse…"
+      "customPlaceholder": "Ou saisissez votre propre réponse…",
+      "other": "Autre chose…"
     },
     "permission": {
       "heading": "L'agent demande une autorisation :"

--- a/apps/desktop/src/i18n/locales/ja/session.json
+++ b/apps/desktop/src/i18n/locales/ja/session.json
@@ -285,7 +285,8 @@
   "interaction": {
     "question": {
       "heading": "エージェントが入力を必要としています",
-      "customPlaceholder": "または自分で回答を入力…"
+      "customPlaceholder": "または自分で回答を入力…",
+      "other": "その他…"
     },
     "permission": {
       "heading": "エージェントが許可を求めています："

--- a/apps/desktop/src/i18n/locales/ko/session.json
+++ b/apps/desktop/src/i18n/locales/ko/session.json
@@ -285,7 +285,8 @@
   "interaction": {
     "question": {
       "heading": "에이전트가 입력을 요청합니다",
-      "customPlaceholder": "또는 직접 답변을 입력하세요…"
+      "customPlaceholder": "또는 직접 답변을 입력하세요…",
+      "other": "기타…"
     },
     "permission": {
       "heading": "에이전트가 권한을 요청합니다:"

--- a/apps/desktop/src/i18n/locales/zh-Hans/session.json
+++ b/apps/desktop/src/i18n/locales/zh-Hans/session.json
@@ -285,7 +285,8 @@
   "interaction": {
     "question": {
       "heading": "代理需要您的输入",
-      "customPlaceholder": "或输入您自己的答案…"
+      "customPlaceholder": "或输入您自己的答案…",
+      "other": "其他…"
     },
     "permission": {
       "heading": "代理请求权限："


### PR DESCRIPTION
Reported: when the agent asks a question you can only pick — choosing an "Other" option gives nowhere to type.

## Real, and worse than it looks

The free-text field exists, but is gated on the asking model setting `custom: true`:

```tsx
{it.custom && <input … />}
```

The SDK carries the flag faithfully, so this is entirely up to the model — and nothing obliges it. A model that offers an "Other" option without the flag leaves no way to say *what*.

The sharper edge: a single question with single-select is **quick-pick**, answering the moment you click. So clicking "Other" did not just fail to offer a field — it submitted the bare word "Other" as the answer, which tells the agent nothing and cannot be taken back.

## Fix

Every question now carries a dashed **"Something else…"** row that reveals the field.

Design notes:

- **Behind a row, not always open.** A question with good options stays a clean list; the hatch is one click away. But it is always there — whether the user can speak for themselves should not be the asking agent's decision to make by omission.
- **The typed text is the answer**, never the label of the row that revealed it.
- **Opening the field ends quick-pick** — there is now something to type and a Submit to press. An empty field keeps Submit disabled.
- **Single-select drops its pick** when the field opens, exactly as choosing another option would. Multi-select keeps its picks alongside the text.
- **A model that did ask for free text** (`custom: true`) still gets the field outright, with no redundant row.

New label in all seven shipped locales.

## Validation

4 new tests: the hatch appears without `custom` and the typed text is what is sent; an empty field cannot submit; multi-select combines picks and text; `custom: true` still shows the field directly and no extra row.

Full suite **973 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean.