### PR TITLE
fix(subagents): keep the link to a subagent's session when history reloads

### DIFF
--- a/apps/desktop/src/lib/runtime.test.ts
+++ b/apps/desktop/src/lib/runtime.test.ts
@@ -325,6 +325,35 @@ describe("historyToThread", () => {
     expect(t.blocks[2]).toMatchObject({ kind: "tool-call", status: "success" });
   });
 
+  // Every subagent in a reloaded conversation was unopenable: the live fold
+  // keeps the spawned session id from the event, but rebuilding history dropped
+  // it, so the panel had nothing to open.
+  it("restores the subagent session a task spawned", () => {
+    const msgs: HistoryMessage[] = [
+      { role: "user", parts: [{ type: "text", text: "go" }] },
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool",
+            tool: "task",
+            state: {
+              status: "completed",
+              title: "Explore data adapters",
+              metadata: { sessionId: "ses_child_1" },
+            },
+          },
+        ],
+      },
+    ];
+    const t = historyToThread(msgs);
+    expect(t.blocks[t.blocks.length - 1]).toMatchObject({
+      kind: "tool-call",
+      tool: "task",
+      childSessionId: "ses_child_1",
+    });
+  });
+
   it("restores reasoning parts on reload as reasoning blocks, before the answer", () => {
     const msgs: HistoryMessage[] = [
       { role: "user", parts: [{ type: "text", text: "hi" }] },

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -3828,6 +3828,12 @@ export function historyToThread(messages: HistoryMessage[], commands?: CommandIn
               : {}),
             ...(typeof p.state?.time?.start === "number" ? { startedAt: p.state.time.start } : {}),
             ...(typeof p.state?.time?.end === "number" ? { endedAt: p.state.time.end } : {}),
+            // The subagent session this task spawned. The live fold keeps it
+            // from the event; rebuilding history dropped it, so every subagent
+            // in a reloaded conversation became unopenable.
+            ...(p.state?.metadata?.sessionId
+              ? { childSessionId: p.state.metadata.sessionId }
+              : {}),
             ...(userShell && p.state?.output?.trim()
               ? { outputSummary: p.state.output.replace(/\s+$/, "") }
               : {}),

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -271,8 +271,11 @@ export interface HistoryPart {
     output?: string;
     /** Epoch ms the tool started/finished — persisted with the part. */
     time?: { start?: number; end?: number };
-    /** Tool-specific extras (bash stdout tail, edit diff, task session link). */
-    metadata?: { output?: string; diff?: string };
+    /** Tool-specific extras (bash stdout tail, edit diff, task session link).
+     *  `sessionId` is the subagent session a `task` tool spawned — the live
+     *  event stream reads the same field, and without it here a RELOADED
+     *  conversation loses every link to its subagents' own transcripts. */
+    metadata?: { output?: string; diff?: string; sessionId?: string };
   };
 }
 


### PR DESCRIPTION
Reported with a screenshot: 13 subagents, not one of them openable.

## Reading the screenshot

None of the rows had a **chevron**. The panel only draws one when the row has a child session to open — so it was not a click-target problem (that was the previous round). It was the panel correctly reporting that it had no session id at all.

## Cause

The live event stream takes the spawned session from the task tool's metadata:

```ts
// A task tool's metadata names the subagent session it spawned.
const child = meta?.sessionId;
```

But the **history** type never declared that field:

```ts
metadata?: { output?: string; diff?: string };
```

so `historyToThread` rebuilt the tool block without it. Every subagent in a reloaded conversation lost its link.

That also explains why this survived review and a test suite: subagents watched **live, in the session that spawned them**, keep the id in memory and open fine — which is what my test seeded. A conversation reopened later, which is the normal case, had nothing.

## Fix

Declare the field and read it in the history rebuild, so both paths take the same one.

## Validation

New test: a completed `task` part with `metadata.sessionId` rebuilds into a block carrying `childSessionId`.

Full suite **974 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean.

Worth checking on the build against an **existing** conversation — a fresh one would have worked before this fix too, which is precisely how I missed it.