### PR TITLE
fix(subagents): lay out an opened transcript as nested content, not a chat

### DIFF
--- a/apps/desktop/src/components/thread/SubagentPane.test.tsx
+++ b/apps/desktop/src/components/thread/SubagentPane.test.tsx
@@ -75,6 +75,9 @@ describe("SubagentPane", () => {
         },
       ],
       "child-1": [
+        // The opening block is the brief the parent handed the subagent, not
+        // the user speaking — it must not render as a chat bubble.
+        { kind: "user", text: "Check the residuals and report blocking issues." },
         { kind: "tool-call", tool: "bash", title: "python3 check.py", status: "success" },
         { kind: "agent", markdown: "The residuals look fine." },
       ],
@@ -93,6 +96,11 @@ describe("SubagentPane", () => {
     expect(row).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByText("The residuals look fine.")).toBeInTheDocument();
     expect(screen.getByText("python3 check.py")).toBeInTheDocument();
+    // The brief is shown, flat — not as the right-aligned user bubble the main
+    // conversation uses, which in a narrow panel read as a ragged indent.
+    const brief = screen.getByText(/Check the residuals/);
+    expect(brief.tagName).toBe("P");
+    expect(brief.className).not.toContain("rounded-card");
 
     await userEvent.click(row);
     expect(screen.queryByText("The residuals look fine.")).not.toBeInTheDocument();

--- a/apps/desktop/src/components/thread/SubagentPane.tsx
+++ b/apps/desktop/src/components/thread/SubagentPane.tsx
@@ -164,9 +164,28 @@ function Transcript({ childId }: { childId: string }) {
       </p>
     );
   }
+  // The leading user block is not the user talking — it is the brief the parent
+  // handed this subagent. Rendered as the chat's own user message it came out as
+  // a right-aligned 85%-wide bubble whose surface matches the row behind it, so
+  // in a narrow panel it read as text randomly indented into a ragged column.
+  // It belongs at the top, full width and quiet, as the task it is.
+  const firstAgentStep = blocks.findIndex((b) => b.kind !== "user");
+  const brief = (firstAgentStep === -1 ? blocks : blocks.slice(0, firstAgentStep))
+    .map((b) => (b.kind === "user" ? b.text : ""))
+    .filter(Boolean)
+    .join("\n\n");
+  const rest = firstAgentStep === -1 ? [] : blocks.slice(firstAgentStep);
+
   return (
-    <div className="mt-1.5 border-t border-border pt-1.5 text-[12px]">
-      <BlockList blocks={blocks} />
+    // A rail marks the whole expansion as this row's content rather than a
+    // sibling of the rows around it.
+    <div className="nested-transcript mt-1.5 border-l border-border pl-2.5">
+      {brief && (
+        <p className="whitespace-pre-wrap break-words pb-2 text-[11px] leading-relaxed text-muted">
+          {brief}
+        </p>
+      )}
+      {rest.length > 0 && <BlockList blocks={rest} />}
     </div>
   );
 }

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -177,6 +177,18 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* A subagent's transcript is a NESTED, secondary read inside a narrow panel.
+   The thread's own type scale (15px body) is sized for the main conversation
+   and overwhelms it there. The block components set their sizes explicitly, so
+   the step down is applied once here rather than threaded as a prop through
+   every one of them. */
+.nested-transcript,
+.nested-transcript p,
+.nested-transcript li {
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
 /* Sidebar icon weight. lucide ships stroke-width 2, which next to the 1.5 of the
    collapse button read thick and slightly fuzzy at these sizes. One rule instead
    of a prop on every call site, so an icon added later matches by default.


### PR DESCRIPTION
Reported with a screenshot: an opened subagent looks wrong, with a strange indent.

## What that indent was

The expansion rendered the subagent's blocks with the main conversation's components unchanged. The opening block is a `UserMessage`, which is a **right-aligned chat bubble**:

```tsx
<div className="group flex flex-col items-end">
  <div className="w-fit max-w-[85%] … rounded-card bg-surface-2 px-4 py-2.5 text-[15px]">
```

In a narrow panel that is a ragged 85%-wide column pushed to the right — and its `bg-surface-2` is the same surface as the row behind it, so the bubble itself is invisible. What is left is text indented against nothing, which is exactly what the screenshot shows.

## It is also not the user

That block is the **brief the parent agent handed this subagent**. Rendering it as something *you* said is wrong regardless of how it looks.

It now sits at the top of the expansion, full width and quiet, as the task it is. The steps and the answer follow it.

## The rest

- **Scale.** The thread's 15px body is sized for the main conversation and overwhelms a nested read in a side panel. The block components set their sizes explicitly, so the step down is applied once in CSS rather than threaded as a prop through every one of them.
- **A rail** down the left says the expansion belongs to its row, instead of appearing to sit between the rows around it.

## Validation

The existing expansion test now seeds a leading user block (which is what a real subagent thread has) and asserts the brief renders as a plain paragraph, not the bubble.

Full suite **974 passed**, 3 skipped; `tsc --noEmit` and `eslint` clean.

Visual — worth opening one of the long ones from your screenshot.
