### PR TITLE
fix(osd-core): canonicalize project path assertions to native form on Windows

### DIFF
--- a/crates/osd-core/src/project.rs
+++ b/crates/osd-core/src/project.rs
@@ -677,7 +677,10 @@ mod tests {
         // What set_workspace persists, and workspace_dir reads back, for the
         // folder the sidebar's "+" hands it (`startDraftInWorkspace(p.path)`) —
         // it canonicalizes, and the layout call returns the dir unchanged.
-        let switched = dir.canonicalize().unwrap().to_string_lossy().to_string();
+        // Both sides are normalized to the native form (`native_path` strips
+        // the `\\?\` verbatim prefix on Windows), the same string OpenCode
+        // reports as a session's directory.
+        let switched = super::super::artifact_file::native_path(&dir.canonicalize().unwrap());
 
         assert_eq!(reported, switched, "a session started in a project must map back to it");
 
@@ -810,7 +813,9 @@ mod tests {
         let info = info_of(reloaded, &stub);
         assert!(info.imported);
         assert_eq!(info.import_mode.as_deref(), Some("in-place"));
-        assert_eq!(info.path, ext.canonicalize().unwrap().to_string_lossy());
+        // The reported path is the native form (no `\\?\` prefix on Windows),
+        // like every path the app hands to OpenCode — see native_path (#76).
+        assert_eq!(info.path, super::super::artifact_file::native_path(&ext.canonicalize().unwrap()));
 
         // Nothing was written into the user's repo (metadata lives in the stub).
         assert!(!ext.join(".openscience").join("project.json").exists());
@@ -820,7 +825,7 @@ mod tests {
         let own_info = info_of(read_meta(&own).unwrap(), &own);
         assert!(!own_info.imported);
         assert_eq!(own_info.import_mode, None);
-        assert_eq!(own_info.path, own.canonicalize().unwrap().to_string_lossy());
+        assert_eq!(own_info.path, super::super::artifact_file::native_path(&own.canonicalize().unwrap()));
         let _ = own_meta;
 
         let _ = fs::remove_dir_all(&base);


### PR DESCRIPTION
## Summary

Three `osd-core` project tests asserted a reported project path against the raw `Path::canonicalize()` output. On Windows, `canonicalize()` returns the `\\?\` verbatim-prefixed form, while the product code deliberately strips that prefix via `artifact_file::native_path` (see the note in `info_of`, referencing #76). The tests therefore failed on Windows only — on macOS/Linux `canonicalize()` never produces the prefix, so the suite stayed green there and the breakage went unnoticed.

## Fix

Normalize the expected value with the same `native_path()` the product code uses, in all three places:

- `a_projects_reported_path_is_what_a_workspace_switch_resolves`
- `imported_project_points_at_its_external_source_without_writing_into_it`
- (the app-created project assertion in the same test)

No product code is touched; macOS/Linux behaviour is unchanged.

## Verification

- `cargo test -p osd-core` on Windows: **168 passed, 0 failed** (previously 166 passed, 2 failed — both were these assertions).
- `cargo clippy -p osd-core --tests`: no new warnings in `project.rs`.

## Notes

This is a test-only fix — the product code's native-form normalization is correct and intentional (a `\\?\`-prefixed path could never match the `directory` OpenCode reports for a session, #76).
