### PR TITLE
domain-check: bioprocess/cross-scale-fit rule

### DIFF
--- a/runtime/skills/core/domain-check/SKILL.md
+++ b/runtime/skills/core/domain-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-check
-description: Use whenever you write or run scientific analysis code (physics, earth/geo, biology, chemistry, social science, or bioprocess/fermentation) in this workspace — before executing it and again after generating results. Runs a deterministic domain-correctness gate that catches code which runs but is scientifically wrong (unit/dimension mismatch, Euclidean distance on lat/lon without a CRS, 0-based/1-based coordinate and strand errors, impossible SMILES valence, uncorrected multiple comparisons, averaging a categorical code, unconstrained kinetic-parameter fits, kLa computed from raw DO instead of the driving force, arithmetic mean of raw CFU counts, ANOVA/Tukey with no assumption check, a curvature DOE design fit with a first-order model). Surfaces structured findings; never claims the code is correct.
+description: Use whenever you write or run scientific analysis code (physics, earth/geo, biology, chemistry, social science, or bioprocess/fermentation) in this workspace — before executing it and again after generating results. Runs a deterministic domain-correctness gate that catches code which runs but is scientifically wrong (unit/dimension mismatch, Euclidean distance on lat/lon without a CRS, 0-based/1-based coordinate and strand errors, impossible SMILES valence, uncorrected multiple comparisons, averaging a categorical code, unconstrained kinetic-parameter fits, kLa computed from raw DO instead of the driving force, arithmetic mean of raw CFU counts, ANOVA/Tukey with no assumption check, a curvature DOE design fit with a first-order model, an ML model fit across process scales with no correction). Surfaces structured findings; never claims the code is correct.
 ---
 
 # Domain-correctness gate
@@ -90,6 +90,14 @@ It prints exactly one ` ```review ` fenced JSON block on stdout.
   file) fit through a `statsmodels` formula with no quadratic (`I(x**2)`) or
   interaction (`x1:x2`) term — the design was built to estimate curvature, so
   a first-order model wastes it and cannot locate an interior optimum.
+- **bioprocess · cross-scale-fit** — a real model fit (`.fit(...)`, guarded to
+  a file that imports scikit-learn, XGBoost, statsmodels, PyTorch,
+  TensorFlow, or Keras — a plain `scipy.curve_fit` never counts) in a file
+  that mentions both a small-scale (flask, bench-scale) and a large-scale
+  (bioreactor, batch, pilot-scale) process vocabulary, e.g. trained on flask
+  data and applied to a bioreactor. Advisory: still fires when a
+  calibration/scaling-factor/cross-validation term is present, since
+  confirming intent matters either way, but with a different message.
 
 Rules favour precision: an unrecognized unit, arithmetic with no discipline
 signal, a SMILES using bracket atoms (which carry their own valence/charge), a

--- a/runtime/skills/core/domain-check/domain_check.py
+++ b/runtime/skills/core/domain-check/domain_check.py
@@ -667,6 +667,74 @@ _RSM_DESIGN_MARKERS = re.compile(
     re.IGNORECASE,
 )
 
+# Small- vs. large-scale process vocabulary. "reactor" alone already covers
+# "bioreactor" as a substring; "flask" is handled separately below (it needs
+# a guard, not just a pattern — see _mentions_lab_flask).
+_BENCH_SCALE = re.compile(r"bench[_-]?scale", re.IGNORECASE)
+_LARGE_SCALE = re.compile(r"reactor|\bbatch|pilot[_-]?scale", re.IGNORECASE)
+
+# Terms marking a cross-scale fit as already accounted for. The rule still
+# fires when one of these is present — confirming intent still matters at
+# scale-up — but with a different message (see check_bioprocess rule 6).
+_SCALE_CORRECTION = re.compile(
+    r"calibrat|scaling[_-]?factor|cross[_-]?valid|correction[_-]?factor",
+    re.IGNORECASE,
+)
+
+# Only these mean "trained a model": gates check_bioprocess rule 6 off
+# scipy.optimize.curve_fit (not model training — see _KINETIC_PARAM_NAMES
+# above) and any other .fit()-shaped API that has nothing to do with ML.
+_ML_LIBRARIES = {"sklearn", "xgboost", "statsmodels", "torch", "tensorflow", "keras"}
+
+
+def _has_ml_import(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(a.name.split(".")[0] in _ML_LIBRARIES for a in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module.split(".")[0] in _ML_LIBRARIES:
+                return True
+    return False
+
+
+# The Flask web framework's own idioms — import line, `Flask(` app
+# construction, `Blueprint(`. Deliberately case-SENSITIVE: the framework's
+# class names are conventionally capitalized, so this does not also exclude
+# a coincidental lowercase `flask(...)` call, which is far more likely to be
+# something else (or an actual lab flask helper) than the framework.
+_FLASK_FRAMEWORK_MARKERS = re.compile(
+    r"^\s*(import\s+flask\b|from\s+flask\b)|\bFlask\s*\(|\bBlueprint\s*\("
+)
+
+
+def _mentions_lab_flask(src: str) -> bool:
+    """True if "flask" appears on a line that isn't one of Flask-the-web-
+    framework's own idioms. It shares its name with a lab flask, and a
+    research script that imports it for a dashboard/API has nothing to do
+    with process scale — case-insensitive matching can't tell the two apart
+    by capitalization alone, so this checks line-by-line instead."""
+    for line in src.splitlines():
+        if _FLASK_FRAMEWORK_MARKERS.search(line):
+            continue
+        if re.search(r"flask", line, re.IGNORECASE):
+            return True
+    return False
+
+
+def _mentions_small_scale(src: str) -> bool:
+    return _mentions_lab_flask(src) or bool(_BENCH_SCALE.search(src))
+
+
+def _is_fit_method_call(node: ast.AST) -> bool:
+    """`x.fit(...)` specifically — not a bare `fit(...)`/`curve_fit(...)`
+    call, which the ML .fit() idiom never is."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "fit"
+    )
+
 
 def _ols_formula_literal(call: ast.Call) -> str | None:
     """The formula string of an `ols(...)` call, positional or `formula=`,
@@ -855,6 +923,39 @@ def check_bioprocess(ctx: Ctx) -> list[Finding]:
                     "curvature — a first-order model cannot estimate it or "
                     "locate an interior optimum.",
                 ))
+
+    # (6) A real model fit (gated to an actual ML library — see
+    #     _has_ml_import — so a plain scipy.curve_fit never counts; that is
+    #     covered by rule 1) in a file that mentions BOTH a small-scale and a
+    #     large-scale process vocabulary, e.g. trained on flask data and
+    #     applied to a bioreactor. Advisory only: this is a confirm-intent
+    #     prompt, not a defect — a deliberate, corrected scale-up is
+    #     completely legitimate, which is why it still fires (with a
+    #     different message) when a calibration/correction term is present.
+    if _mentions_small_scale(ctx.src) and _LARGE_SCALE.search(ctx.src) \
+            and _has_ml_import(ctx.tree):
+        fit_call = next((n for n in ast.walk(ctx.tree) if _is_fit_method_call(n)), None)
+        if fit_call is not None:
+            if _SCALE_CORRECTION.search(ctx.src):
+                title = "Cross-scale model fit alongside a calibration/correction term"
+                detail = (
+                    "Multiple process scales detected along with a "
+                    "calibration/correction term. Verify that the scaling "
+                    "factor is appropriate for this case."
+                )
+            else:
+                title = "Model fit spans multiple process scales, no correction found"
+                detail = (
+                    "Multiple process scales detected in this file (e.g. "
+                    "flask, bioreactor). A model trained at one scale may "
+                    "not transfer directly to another without "
+                    "cross-validation or a correction factor. Confirm if "
+                    "this is intentional."
+                )
+            out.append(Finding(
+                "warn", "bioprocess · cross-scale-fit", title,
+                ctx.snippet(ctx.line_of(fit_call)) + "\n  " + detail,
+            ))
     return out
 
 

--- a/scripts/dev/test_domain_check.py
+++ b/scripts/dev/test_domain_check.py
@@ -428,6 +428,96 @@ class Bioprocess(unittest.TestCase):
         )
         self.assertNotIn("bioprocess · rsm-first-order-fit", tags(src))
 
+    def test_cross_scale_fit_no_correction(self):
+        src = (
+            "from sklearn.ensemble import RandomForestRegressor\n"
+            "flask_titre = load_flask_runs()\n"
+            "model = RandomForestRegressor()\n"
+            "model.fit(flask_titre[['time', 'temp']], flask_titre['od600'])\n"
+            "bioreactor_pred = model.predict(bioreactor_features)\n"
+        )
+        self.assertIn("bioprocess · cross-scale-fit", tags(src))
+
+    def test_single_scale_fit_ok(self):
+        # Same file, but every reference is to the same scale (flask) -> the
+        # rule needs BOTH categories present, not just a model fit.
+        src = (
+            "from sklearn.ensemble import RandomForestRegressor\n"
+            "flask_titre = load_flask_runs()\n"
+            "model = RandomForestRegressor()\n"
+            "model.fit(flask_titre[['time', 'temp']], flask_titre['od600'])\n"
+            "pred = model.predict(other_flask_features)\n"
+        )
+        self.assertNotIn("bioprocess · cross-scale-fit", tags(src))
+
+    def test_both_scales_no_fit_call_ok(self):
+        # Both scale categories mentioned (e.g. a comparison plot), but no
+        # model is ever fit -> nothing to warn about transferring.
+        src = (
+            "import matplotlib.pyplot as plt\n"
+            "flask_od = [0.1, 0.5, 1.2]\n"
+            "bioreactor_od = [0.1, 0.6, 1.4]\n"
+            "plt.plot(flask_od, label='flask')\n"
+            "plt.plot(bioreactor_od, label='bioreactor')\n"
+        )
+        self.assertNotIn("bioprocess · cross-scale-fit", tags(src))
+
+    def test_cross_scale_fit_with_correction_term(self):
+        # A calibration/correction term is present -> still fires (confirming
+        # intent still matters), but with the correction-term message.
+        src = (
+            "from sklearn.linear_model import LinearRegression\n"
+            "# apply a scaling_factor calibration between flask and bioreactor\n"
+            "flask_data = load_flask()\n"
+            "model = LinearRegression()\n"
+            "model.fit(flask_data.X, flask_data.y)\n"
+            "pred = model.predict(bioreactor_data.X)\n"
+        )
+        findings_ = [f for f in findings(src) if f.tag == "bioprocess · cross-scale-fit"]
+        self.assertEqual(len(findings_), 1)
+        self.assertIn("calibration/correction term", findings_[0].title)
+        self.assertIn("scaling factor is appropriate", findings_[0].evidence)
+
+    def test_curve_fit_not_ml_library_ok(self):
+        # scipy.optimize.curve_fit mixes both scales, but it is not model
+        # training (no ML library imported, and it's never a `.fit()` method
+        # call) -> the guard this rule exists to enforce.
+        src = (
+            "from scipy.optimize import curve_fit\n"
+            "def model(x, a, b):\n"
+            "    return a * x + b\n"
+            "flask_x = [1, 2, 3]\n"
+            "bioreactor_y = [4, 5, 6]\n"
+            "popt, _ = curve_fit(model, flask_x, bioreactor_y)\n"
+        )
+        self.assertNotIn("bioprocess · cross-scale-fit", tags(src))
+
+    def test_random_forest_cross_scale_fit(self):
+        # RandomForestClassifier as its own dedicated case, distinct from the
+        # regressor above.
+        src = (
+            "from sklearn.ensemble import RandomForestClassifier\n"
+            "clf = RandomForestClassifier()\n"
+            "clf.fit(flask_X, flask_y)\n"
+            "pred = clf.predict(bioreactor_X)\n"
+        )
+        self.assertIn("bioprocess · cross-scale-fit", tags(src))
+
+    def test_flask_web_framework_not_lab_flask_ok(self):
+        # The Flask web framework shares its name with a lab flask. A script
+        # that happens to import Flask (for a dashboard, say) alongside an
+        # unrelated bioreactor mention and an ML fit must not be told its
+        # model crosses scales -- it never mentioned a lab flask at all.
+        src = (
+            "from flask import Flask\n"
+            "app = Flask(__name__)\n"
+            "bioreactor_status = get_status()\n"
+            "from sklearn.linear_model import LinearRegression\n"
+            "model = LinearRegression()\n"
+            "model.fit(X, y)\n"
+        )
+        self.assertNotIn("bioprocess · cross-scale-fit", tags(src))
+
 
 class Driver(unittest.TestCase):
     def test_run_emits_contract(self):


### PR DESCRIPTION
## Summary

Adds `bioprocess · cross-scale-fit` to the `domain-check` gate (`runtime/skills/core/domain-check/domain_check.py`), following the same `check_<field>` extension pattern PR #127 used for the rest of `check_bioprocess`.

Detects a real model fit-and-predict across process scales — flask versus bioreactor — with no correction step:

- Fires when a file mentions **both** a small-scale keyword (`flask`, `bench-scale`) and a large-scale one (`bioreactor`/`reactor`, `batch`, `pilot-scale`), searched case-insensitively across identifiers, comments, and strings.
- Only counts a fit if it's a real `.fit(...)` **method** call in a file that imports one of scikit-learn, XGBoost, statsmodels, PyTorch, TensorFlow, or Keras — a plain `scipy.optimize.curve_fit` never qualifies (that's already `check_bioprocess`'s `unconstrained-kinetics` rule's territory), and requiring an attribute call structurally excludes it regardless of the import guard.
- If a calibration/scaling-factor/cross-validation/correction-factor term is present anywhere in the file, the rule still fires — confirming intent still matters at a deliberate, corrected scale-up — but with a different message.
- Advisory only: `warn`, never `error`. This is a "confirm intent" prompt, not a defect finding.

Also guards a name collision the case-insensitive scale search would otherwise hit: the Flask web framework shares its name with a lab flask. A file that `import flask`s for a dashboard/API, or constructs `Flask(__name__)`, is excluded from the lab-flask check on those specific lines — the same kind of narrow, explained guard as the existing `\bkla` vs. "Oklahoma" fix.

## Test plan

- [x] 7 new unit tests in `scripts/dev/test_domain_check.py`, mirroring the existing `unittest` style: cross-scale fit with no correction, single-scale-only (negative), both scales with no fit call (negative), cross-scale fit with a correction term (different message), `scipy.curve_fit` with no ML import (negative — the guard this rule exists to enforce), `RandomForestClassifier` as its own dedicated case, and the Flask-framework guard.
- [x] `python scripts/dev/test_domain_check.py` — 67/67 pass (60 existing + 7 new).
- [x] `python runtime/skills/core/domain-check/domain_check.py` run over the whole repository — zero findings, confirming no false positives.
- [x] `python -m py_compile` on both modified Python files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)