### PR TITLE
fix(osd-core): make two tests pass on Windows — valid JSON fixtures, path-wise compare

### DIFF
--- a/crates/osd-core/src/runtime.rs
+++ b/crates/osd-core/src/runtime.rs
@@ -2408,9 +2408,14 @@ mod tests {
             .collect();
         assert_eq!(aside.len(), 1, "{aside:?}");
         assert_eq!(fs::read_to_string(&aside[0]).unwrap(), broken);
+        // Compare as paths, not strings: `aside` was built from the mixed
+        // separator spelling above (`runtime/xdg-config/…`), while the notice
+        // records the production code's native join spelling. On Windows the
+        // two strings differ but name the same file — `Path` equality compares
+        // by component, so `/` and `\` no longer matter.
         assert_eq!(
-            super::take_config_quarantine_notice(&env).as_deref(),
-            Some(aside[0].to_string_lossy().as_ref()),
+            super::take_config_quarantine_notice(&env).map(std::path::PathBuf::from),
+            Some(aside[0].clone()),
             "the user is told, with the path"
         );
 

--- a/crates/osd-core/src/session_sync.rs
+++ b/crates/osd-core/src/session_sync.rs
@@ -353,9 +353,16 @@ mod tests {
 
         let mirror = root.join("mirror");
         std::fs::create_dir_all(&mirror).unwrap();
+        // The mirror file is a real `opencode export`'s JSON. Building the
+        // fixture by hand with `format!` put a Windows path (backslashes) into
+        // the JSON, where `\U`, `\b`, `\s`… are illegal escapes — so the export
+        // parsed as nothing and every case silently fell back to the base
+        // folder. Build it with serde instead, exactly like the runtime does,
+        // and the escaping is right on every platform.
         let write = |name: &str, dir: &str| {
             let f = mirror.join(name);
-            std::fs::write(&f, format!(r#"{{"info":{{"directory":"{dir}"}},"messages":[]}}"#)).unwrap();
+            let text = serde_json::json!({ "info": { "directory": dir }, "messages": [] }).to_string();
+            std::fs::write(&f, text).unwrap();
             f
         };
 


### PR DESCRIPTION
Two `osd-core` tests were permanently red on Windows, failing from clean master (`cc2d746`) with no in-flight change involved. The maintainer develops on macOS and never sees them; the same class of Windows test-path fix was accepted before as #128 (`d8237a9`), which is why this is a small PR rather than an issue first. Both failures were defects in the tests' own setup, so the change is **test-only — no production line moves**.

## Failure 1 — `session_sync::tests::an_import_is_filed_in_a_folder_this_machine_actually_has`

The test built its mirror-file fixtures with `format!`, interpolating a Windows path (backslashes) into JSON, where `\U`, `\b`, `\s`… are illegal escapes. Every fixture therefore failed to parse, and `import_dir` took its designed "unreadable mirror → fall back to the base folder" branch for ALL cases — assertion 1 failed, and assertions 3 and 4 passed **for the wrong reason**, never actually exercising their logic on Windows. The fixtures are now built with `serde_json`, exactly as the runtime's own exporter writes them, so escaping is correct on every platform. Assertions 3 and 4 now genuinely run their paths (verified by temporarily disabling the containment check in `import_dir`: assertion 3 went red as intended, then reverted).

## Failure 2 — `runtime::tests::a_broken_config_is_recovered_and_the_real_runtime_then_serves`

The test compared two path *strings* that name the same file with different separator spellings: the quarantine notice records the production code's native `PathBuf::join` spelling, while the aside file was read back through the fixture's mixed-separator literal. On Windows the strings differ; the paths are the same. The assertion now compares `Path` values, whose equality is by component and treats `/` and `\` alike — the production side (native joins) is untouched.

## Why test-only is enough

- Production fixtures are written by the runtime's own exporter (serde) — escaping is correct there.
- Production paths are built with native `PathBuf::join` — the separator spelling is consistent there.
- Both sides of each failure were test-construction artifacts; no production behaviour needed changing.

## Verification (Windows, local, scoped to the crates)

- `cargo test -p osd-core -- an_import_is_filed... a_broken_config...`: **2 passed** (before: 2 failed on clean master, same machine)
- `cargo test -p osd-core session_sync`: 11 passed
- `cargo test -p osd-core a_broken_config`: 1 passed — a real runtime run (6.2 s, no "skipped: no bundled opencode")
- `cargo test -p osd-core -p osd-cli`: 183 + 10 passed, 0 failed
- `cargo clippy -p osd-core -p osd-cli --all-targets`: no new warnings (the pre-existing baseline is unchanged)