### PR TITLE
fix(#139): stop caching a failed history load as a loaded thread

### DIFF
--- a/apps/desktop/src/app/routes/LiveSessionPage.tsx
+++ b/apps/desktop/src/app/routes/LiveSessionPage.tsx
@@ -161,6 +161,13 @@ export function LiveSessionPage() {
   // /clear thread (currentId is already null then).
   useEffect(() => {
     if (focusedSid) {
+      // Wait for the runtime, exactly as the background-pane effect above
+      // already does. A restored tab used to fire this the moment it mounted,
+      // racing a sidecar that can take seconds to accept connections — the
+      // fetch failed at the network level and the session showed "Failed to
+      // load messages" (#139). `connected` is a dependency, so this re-runs and
+      // opens the session the moment the runtime is up.
+      if (!connected) return;
       void openSession(focusedSid);
     } else if (useRuntimeStore.getState().currentId) {
       // View-only reset: re-blanking a pane must not reroute the next session

--- a/apps/desktop/src/components/session/SessionView.launch.test.tsx
+++ b/apps/desktop/src/components/session/SessionView.launch.test.tsx
@@ -7,7 +7,13 @@ import { useRuntimeStore } from "@/lib/runtime";
 // found it at, so no other suite inherits a faked one.
 const RUNTIME_STATUS = useRuntimeStore.getState().status;
 afterEach(() => {
-  useRuntimeStore.setState({ status: RUNTIME_STATUS, error: null });
+  useRuntimeStore.setState({
+    status: RUNTIME_STATUS,
+    error: null,
+    sessions: [],
+    threads: {},
+    currentId: null,
+  });
   vi.useRealTimers();
 });
 
@@ -42,5 +48,35 @@ describe("a session pane while the runtime is starting", () => {
     renderAt("/live");
     expect(await screen.findByText("OpenCode runtime")).toBeInTheDocument();
     expect(screen.queryByText("Starting the local runtime…")).not.toBeInTheDocument();
+  });
+});
+
+/** The skeleton means "nothing to show yet", NOT "history unfetched" — the two
+ *  came apart in #139. A failed load keeps `loaded: false` so the next open
+ *  retries, and it is the error row that stops the spinner. Keying the skeleton
+ *  off `loaded` again would hand that session an endless pulse instead, which
+ *  is the bug 1620a1f fixed and no store test can see. */
+describe("a session pane whose history failed to load", () => {
+  it("shows the error row rather than pulsing forever", async () => {
+    act(() =>
+      useRuntimeStore.setState({
+        status: "ready",
+        error: null,
+        sessions: [{ id: "ses_err", title: "Broken", directory: "/ws/base" }],
+        currentId: "ses_err",
+        threads: {
+          ses_err: {
+            blocks: [
+              { kind: "status-line", text: "Failed to load messages: Load failed", tone: "error" },
+            ],
+            index: {},
+            loaded: false,
+          },
+        },
+      }),
+    );
+    const { container } = renderAt("/live/ses_err");
+    expect(await screen.findByText("Failed to load messages: Load failed")).toBeInTheDocument();
+    expect(container.querySelector(".animate-pulse")).toBeNull();
   });
 });

--- a/apps/desktop/src/components/session/SessionView.tsx
+++ b/apps/desktop/src/components/session/SessionView.tsx
@@ -336,7 +336,13 @@ export function SessionView({
 
   // This session's thread, selected on its own so only its own folds repaint.
   const thread = useRuntimeStore((s) => s.threads[key]);
-  const historyLoading = connected && !!eid && !thread?.loaded;
+  // The skeleton means "still waiting, with nothing at all to show" — NOT
+  // "history unfetched". Those came apart in #139: a failed load has an error
+  // row to render and must still count as unfetched, so the next open retries
+  // instead of short-circuiting on it. Keying the skeleton off `loaded` alone
+  // forced the catch to lie about the history to stop the spinner (1620a1f),
+  // which is what cached the failure for the whole app run.
+  const historyLoading = connected && !!eid && !thread?.loaded && !thread?.blocks.length;
   const title = sessions.find((s) => s.id === eid)?.title;
   const isEmpty = !thread || thread.blocks.length === 0;
   const working = sending || running;

--- a/apps/desktop/src/lib/runtime.store.test.ts
+++ b/apps/desktop/src/lib/runtime.store.test.ts
@@ -1098,7 +1098,11 @@ describe("per-session workspace folders", () => {
     expect(mocks.clientOpts.length).toBeGreaterThan(connectsBeforeNextTurn);
   });
 
-  it("openSession stops the loading skeleton when history fails to load", async () => {
+  // 1620a1f's contract: a failed history load renders an error row rather than
+  // an endless skeleton. SessionView stops the skeleton on "there is something
+  // to show", so the error block is what satisfies it — the thread must NOT
+  // claim to be loaded, which is the rest of this trio.
+  it("openSession renders an error row, not an endless skeleton, when history fails", async () => {
     mocks.failMessages = true;
     useRuntimeStore.setState({
       sessions: [{ id: "ses_bad", title: "Bad session", directory: "/ws/base" }],
@@ -1109,10 +1113,62 @@ describe("per-session workspace folders", () => {
     await useRuntimeStore.getState().openSession("ses_bad");
 
     const thread = useRuntimeStore.getState().threads.ses_bad;
-    expect(thread.loaded).toBe(true);
     expect(thread.blocks).toEqual([
       { kind: "status-line", text: "Failed to load messages: history hung", tone: "error" },
     ]);
+    // Something to show, so no skeleton — and still unfetched, so the next open
+    // retries instead of short-circuiting.
+    expect(thread.blocks.length).toBeGreaterThan(0);
+    expect(thread.loaded).toBe(false);
+  });
+
+  // #139: the sidecar can take seconds to accept connections, so the first open
+  // of a restored tab loses the race. Caching that as loaded left the session
+  // reading "Failed to load messages" for the entire app run — reopening it,
+  // switching Screens, and navigating away and back all returned early.
+  it("openSession retries the history once the runtime comes up", async () => {
+    mocks.failMessages = true;
+    useRuntimeStore.setState({
+      sessions: [{ id: "ses_late", title: "Late", directory: "/ws/base" }],
+      currentId: null,
+      threads: {},
+    });
+    await useRuntimeStore.getState().openSession("ses_late");
+    expect(useRuntimeStore.getState().threads.ses_late.loaded).toBe(false);
+
+    // The sidecar is up; the focus effect re-runs on `connected`.
+    mocks.failMessages = false;
+    mocks.messages = [{ role: "user", parts: [{ type: "text", text: "earlier turn" }] }];
+    await useRuntimeStore.getState().openSession("ses_late");
+
+    const thread = useRuntimeStore.getState().threads.ses_late;
+    expect(thread.loaded).toBe(true);
+    expect(thread.blocks).toEqual([{ kind: "user", text: "earlier turn" }]);
+  });
+
+  // The composer stays live behind that error row, so the failure above must not
+  // be compounded by the echo: marking the thread loaded on send stranded the
+  // real history permanently, with nothing on screen but the message just typed.
+  it("sending into a session whose history never loaded does not strand it", async () => {
+    useRuntimeStore.setState({
+      sessions: [{ id: "ses_send", title: "Send", directory: "/ws/base" }],
+      currentId: "ses_send",
+      workspace: "/ws/base",
+      threads: {},
+    });
+
+    await useRuntimeStore.getState().sendPrompt("hello", "ses_send");
+    expect(useRuntimeStore.getState().threads.ses_send.loaded).toBe(false);
+
+    mocks.messages = [
+      { role: "user", parts: [{ type: "text", text: "earlier turn" }] },
+      { role: "assistant", parts: [{ type: "text", text: "earlier reply" }] },
+    ];
+    await useRuntimeStore.getState().openSession("ses_send");
+
+    const thread = useRuntimeStore.getState().threads.ses_send;
+    expect(thread.loaded).toBe(true);
+    expect(thread.blocks.map((b) => b.kind)).toEqual(["user", "agent"]);
   });
 
   it("switchWorkspace pins the chosen folder; startDraft un-pins it", async () => {

--- a/apps/desktop/src/lib/runtime.ts
+++ b/apps/desktop/src/lib/runtime.ts
@@ -1010,8 +1010,8 @@ function raiseStallWarning(sid: string, v: StallVerdict): void {
         threads: {
           ...s.threads,
           [sid]: {
+            // `loaded` inherited, not asserted: a status line is not history (#139).
             ...cur,
-            loaded: true,
             blocks: [
               ...cur.blocks,
               { kind: "status-line", text: channelText, tone: "error", stall: { key } },
@@ -1569,8 +1569,15 @@ async function performTurn(
       threads: {
         ...s.threads,
         [echoKey]: {
+          // `loaded` is inherited, never asserted: echoing a message says
+          // nothing about whether this session's earlier history was ever
+          // fetched. Claiming it here stranded that history permanently —
+          // sending into a session whose load had failed (#139 leaves the
+          // composer live) left the thread holding the echo alone, with every
+          // later open short-circuiting. A brand-new session is the one case
+          // where the draft conversation IS the whole history, and the graft
+          // below says so where it is actually true.
           ...cur,
-          loaded: true,
           blocks: showEcho ? [...cur.blocks, { kind: "user", text: echo }] : cur.blocks,
         },
       },
@@ -1635,8 +1642,15 @@ async function performTurn(
       id = await withRetry(() => client!.createSession());
       set((s) => {
         // Graft this pane's draft conversation (and its pane state) from its own
-        // slot (`draftSrc`) onto the real session id.
-        const threads = { ...s.threads, [id!]: s.threads[draftSrc] ?? emptyThread() };
+        // slot (`draftSrc`) onto the real session id. `loaded` is set HERE, the
+        // one place it is true by construction: the session was created a line
+        // ago, so the draft conversation is its entire history and there is
+        // nothing on the server to fetch. Every other write of this flag either
+        // fetched the history or must leave it alone.
+        const threads = {
+          ...s.threads,
+          [id!]: { ...(s.threads[draftSrc] ?? emptyThread()), loaded: true },
+        };
         delete threads[draftSrc];
         const panes = { ...s.panes };
         if (panes[draftSrc]) {
@@ -1777,8 +1791,8 @@ async function performTurn(
         threads: {
           ...s.threads,
           [key]: {
+            // `loaded` inherited, not asserted: a status line is not history (#139).
             ...cur,
-            loaded: true,
             blocks: [...cur.blocks, { kind: "status-line", text: `Send failed: ${msg}`, tone: "error" }],
           },
         },
@@ -1884,10 +1898,11 @@ function finishAutoReview(
       );
       index[`review:${partId}`] = insertAt;
       threads[job.parentId] = {
+        // `loaded` inherited, not asserted: splicing a review result in says
+        // nothing about whether the parent's own history was ever fetched (#139).
         ...parent,
         blocks,
         index,
-        loaded: true,
       };
     }
     return {
@@ -3066,8 +3081,8 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
               threads: {
                 ...s.threads,
                 [sid]: {
+                  // `loaded` inherited, not asserted: a status line is not history (#139).
                   ...cur,
-                  loaded: true,
                   blocks: [...cur.blocks, { kind: "status-line", text: message, tone: "error" }],
                 },
               },
@@ -4051,13 +4066,24 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (seq !== openSessionSeq || get().currentId !== id) return;
+      // Show the failure, but do NOT claim the history is loaded. `loaded` is
+      // exactly what the early return above consults, so marking it here cached
+      // a TRANSIENT failure forever: a sidecar still accepting connections
+      // refuses this fetch, and the session then read "Failed to load messages"
+      // for the rest of the app run — reopening it, switching Screens, and
+      // navigating away and back all short-circuited on the cached thread
+      // (#139). Leaving it unloaded lets the next open retry, which the focus
+      // effect already performs when `connected` flips.
+      //
+      // The error block is what stops the skeleton now: SessionView renders one
+      // only while there is nothing at all to show, so the endless skeleton
+      // 1620a1f fixed stays fixed without this lie about the history.
       set((s) => ({
         error: msg,
         threads: {
           ...s.threads,
           [id]: {
             ...emptyThread(),
-            loaded: true,
             blocks: [{ kind: "status-line", text: `Failed to load messages: ${msg}`, tone: "error" }],
           },
         },
@@ -4266,8 +4292,8 @@ export const useRuntimeStore = create<RuntimeState>((set, get) => ({
           ...s.threads,
           ...settled,
           [sid]: {
+            // `loaded` inherited, not asserted: a status line is not history (#139).
             ...(settled[sid] ?? cur),
-            loaded: true,
             blocks: [
               ...(settled[sid] ?? cur).blocks,
               { kind: "status-line", text: "Interrupted", tone: "error" },


### PR DESCRIPTION
Closes #139.

## What happened

A session restored into a screen tab fetches its history the moment the tab mounts, racing a sidecar that can take seconds to accept connections (~6s on the reporter's machine, every launch). The fetch fails at the network level, the catch writes the thread as `{ loaded: true, blocks: [error] }`, and every later open short-circuits on `if (get().threads[id]?.loaded) return`. The session then reads "Failed to load messages" for the entire app run.

The reporter's root-cause reading was exact, and reproduced here on current master (not just the `882f3b3` they read — `runtime.ts` has moved 487 lines since, none of it on this path).

## Why the obvious fix is wrong

`loaded: true` in that catch is deliberate — 1620a1f, *"render an error row instead of an endless skeleton"* — because `SessionView` keyed its skeleton off the same flag, and there is a test asserting it. Simply dropping it trades a permanent error for a permanent skeleton and silently re-opens the July bug.

One field was carrying two contracts. This separates them instead of trading them off:

- the skeleton now means **"nothing at all to show"** — the error row stops it, so 1620a1f's fix holds;
- `loaded` now means only **"history was fetched"** — the catch leaves it false, so the next open retries, which the focus effect already performs when `connected` flips;
- that effect also gains the readiness gate its immediate neighbour (background panes, via `loadHistory`) always had, so the doomed fetch never fires during a normal start.

## Wider than the report

Five more sites asserted completeness they did not have, appending a status line to a possibly-unfetched thread: the send echo, a send failure, the stall notice, a turn error, and interrupt. The echo one strands history **on its own, with no network failure involved** — verified; and it compounds the reported bug, since the composer stays live behind the error row, so sending leaves the thread holding just the typed message with the real conversation gone. All five now inherit `loaded`; the draft graft sets it where it is true by construction.

Left alone deliberately: `applyFold` still marks threads loaded — `loadHistory`'s "a live fold beat us to it" guard depends on it, and replacing a live thread with an older snapshot would drop streamed content.

## Verification

Three store tests and one render test, each mutation-checked against its own fix (reverting the fix turns that test red). The skeleton contract needed the render test: no store test can see it, and with the old condition restored that session pulses forever.

1269 desktop tests (3 new), tsc, eslint and the build clean.